### PR TITLE
docs: add README and MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Geolonia Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,164 @@
+# yuuhitsu (右筆)
+
+AI-powered document operations CLI
+
+## Overview
+
+**yuuhitsu** (右筆, meaning "secretary" or "scribe" in feudal Japan) is a command-line tool that automates document operations using AI. The name refers to scribes who served feudal lords, writing and managing official documents on their behalf — this tool serves engineers in the same way, handling translation, documentation generation, and document synchronization.
+
+### Key Capabilities
+
+- **Markdown Translation**: Translate documents while preserving structure, code blocks, and formatting
+- **Multi-Provider Support**: Switch between Claude (Anthropic), Gemini (Google), and Ollama (local) with a single config line change
+- **Streaming Output**: See translation progress in real-time
+- **Dry-Run Mode**: Preview operations without making API calls
+- **Prompt Templates**: Customize AI behavior with configurable templates
+
+## Features
+
+### Translation (Available Now)
+
+- Translate Markdown documents between languages
+- Preserve document structure (headings, links, code blocks, tables)
+- Support for large files with automatic chunking
+- Real-time streaming output
+- Retry logic with exponential backoff for API failures
+
+### Coming Soon
+
+- **generate-docs**: Generate documentation from source code or specifications
+- **sync-docs**: Convert external Markdown to VitePress-compatible format
+- **research**: Perform web research and generate structured reports
+- **fix-links**: Detect and fix dead links in documentation
+- **generate-tests**: Generate test scaffolding from source code
+
+## Quick Start
+
+### Installation
+
+```bash
+npm install -g yuuhitsu
+```
+
+### Basic Usage
+
+```bash
+# Translate a document to Japanese
+yuuhitsu translate --input README.md --lang ja
+
+# Translate to English
+yuuhitsu translate --input docs.md --lang en --output docs.en.md
+
+# Preview without API calls
+yuuhitsu translate --input README.md --lang ja --dry-run
+
+# Use a specific config file
+yuuhitsu translate --input README.md --lang ja --config ./custom.config.yaml
+```
+
+## Configuration
+
+Create a `yuuhitsu.config.yaml` file in your project root:
+
+```yaml
+# AI Provider Selection
+provider: claude  # Options: claude, gemini, ollama
+model: claude-sonnet-4-5-20250929
+
+# Optional Settings
+outputDir: ./translated
+templates: ./templates
+log:
+  enabled: true
+  path: ./yuuhitsu.log
+```
+
+### Environment Variables
+
+Create a `.env` file or set environment variables for API authentication:
+
+```bash
+# For Claude (Anthropic)
+ANTHROPIC_API_KEY=your_api_key_here
+
+# For Gemini (Google)
+GOOGLE_API_KEY=your_api_key_here
+
+# Ollama requires no API key (runs locally)
+```
+
+### Supported Providers
+
+| Provider | SDK | Environment Variable | Use Case |
+|----------|-----|---------------------|----------|
+| Claude | `@anthropic-ai/sdk` | `ANTHROPIC_API_KEY` | High-quality translation, research tasks |
+| Gemini | `@google/genai` | `GOOGLE_API_KEY` | Fast processing, cost-effective |
+| Ollama | `openai` (compatible) | *(none)* | Local execution, privacy, offline use |
+
+## Commands
+
+### `translate`
+
+Translate Markdown documents between languages.
+
+**Options:**
+
+- `--input <path>` (required): Input Markdown file path
+- `--output <path>`: Output file path (defaults to input file with `.{lang}.md` suffix)
+- `--lang <code>` (required): Target language code (e.g., `en`, `ja`, `zh`, `es`)
+- `--provider <name>`: Override config provider (claude, gemini, ollama)
+- `--model <name>`: Override config model
+- `--dry-run`: Show what would be done without making API calls
+- `--stream`: Enable streaming output (default: true)
+- `--config <path>`: Config file path (default: `./yuuhitsu.config.yaml`)
+- `--verbose`: Enable verbose output
+
+**Example:**
+
+```bash
+yuuhitsu translate \
+  --input ./docs/guide.md \
+  --output ./docs/guide.ja.md \
+  --lang ja \
+  --provider claude \
+  --model claude-sonnet-4-5-20250929
+```
+
+## Development
+
+```bash
+# Clone the repository
+git clone https://github.com/geolonia/yuuhitsu.git
+cd yuuhitsu
+
+# Install dependencies
+npm install
+
+# Run tests
+npm test
+
+# Build the project
+npm run build
+
+# Run locally (development)
+npm run dev -- translate --input test.md --lang ja
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Watch mode
+npm run test:watch
+
+# Type checking
+npm run lint
+```
+
+## License
+
+MIT — See [LICENSE](./LICENSE)
+
+Copyright (c) 2026 Geolonia Inc.


### PR DESCRIPTION
## Summary
- Add README.md with project overview, installation, usage, and configuration
- Add MIT LICENSE file (Copyright 2026 Geolonia Inc.)
- Confirm package.json already has `"license": "MIT"`

## Features Documented
- **Available Now**: translate command with all options and examples
- **Coming Soon**: generate-docs, sync-docs, research, fix-links, generate-tests (clearly marked)

## Test plan
- [ ] README content is accurate and matches implementation
- [ ] LICENSE file contains standard MIT text
- [ ] package.json license field is "MIT" (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)