### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow
- Run lint (tsc --noEmit), test (vitest), and build (tsc) on PRs and pushes to main
- Node.js 20.x and 22.x matrix
- All actions pinned to SHA for security

## Actions SHA Pinning
- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` # v4.3.1
- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` # v4.4.0

## Local Verification
✅ lint: PASS (tsc --noEmit)
✅ test: PASS (38 tests, 0 skipped)
✅ build: PASS (tsc)

## Test plan
- [ ] CI passes on this PR (Node 20 + 22)
- [ ] All 38 tests pass, 0 skipped
- [ ] Lint and build succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration to automatically test and build the project across multiple Node.js versions on every pull request and push to the main branch, improving code quality and ensuring compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->