### PR TITLE
fix: add prepare script for auto tsc build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "dev": "tsx src/cli/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Added `"prepare": "tsc"` to package.json scripts
- This makes TypeScript compilation run automatically during `npm install` or `pnpm install`
- Ensures dist/ directory is generated when installing directly from GitHub
- Resolves the issue where the CLI was not executable after GitHub-based installation

## Test plan
- [x] npm test PASS (38/38 tests passed, 0 skipped)
- [x] npm run lint PASS (no TypeScript errors)
- [x] Verified the prepare script is properly added to package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated TypeScript compilation to the package preparation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->