### PR TITLE
improve: enhance translation prompt for Japanese quality

### DIFF
--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -29,7 +29,13 @@ Rules:
 - Do not translate code blocks, URLs, or file paths
 - Do not translate frontmatter keys (only translate values where appropriate)
 - Maintain the same document structure
-- Produce natural, fluent text in the target language`;
+- Produce natural, fluent text in the target language
+
+Additional rules for Japanese translation:
+- Use full-width punctuation: 。、？！ (not .,?!)
+- Add half-width spaces around English words and numbers (e.g., "Vela とは", "NGSIv2 は", "3 つの")
+- Use natural Japanese terms for technical words where appropriate (e.g., "registration" → "登録", "subscription" → "サブスクリプション")
+- Keep product names, proper nouns, and abbreviations unchanged (e.g., Vela, FIWARE, NGSIv2, NGSI-LD, MCP)`;
 
 function buildPrompt(
   content: string,

--- a/src/templates/translate.md
+++ b/src/templates/translate.md
@@ -7,6 +7,12 @@ Rules:
 - Maintain the same document structure
 - Produce natural, fluent text in the target language
 
+Additional rules for Japanese translation:
+- Use full-width punctuation: 。、？！ (not .,?!)
+- Add half-width spaces around English words and numbers (e.g., "Vela とは", "NGSIv2 は", "3 つの")
+- Use natural Japanese terms for technical words where appropriate (e.g., "registration" → "登録", "subscription" → "サブスクリプション")
+- Keep product names, proper nouns, and abbreviations unchanged (e.g., Vela, FIWARE, NGSIv2, NGSI-LD, MCP)
+
 Document to translate:
 
 {{content}}


### PR DESCRIPTION
## Summary
- Added translation prompt rules for Japanese quality improvement
- Full-width punctuation (。、？！)
- Half-width spaces around English words/numbers
- Natural Japanese terms for technical words
- Keep product names unchanged (Vela, FIWARE, etc.)

## Test plan
- [x] npm test PASS (38 tests passed)
- [x] npm run lint PASS
- [x] Prompt rules correctly added to both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a formatting issue in translation configuration affecting output quality.

* **New Features**
  * Added Japanese translation guidelines including proper punctuation, spacing conventions, technical terminology handling, and proper noun preservation for improved translation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->