### PR TITLE
fix: auto-load .env from cwd when envDir not specified

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,9 +21,11 @@ export async function loadConfig(
   configPath: string,
   envDir?: string
 ): Promise<AppConfig> {
-  // Load .env if envDir is provided
+  // Load .env - from envDir if provided, otherwise from cwd
   if (envDir) {
     dotenvConfig({ path: join(envDir, ".env") });
+  } else {
+    dotenvConfig(); // Loads from cwd by default
   }
 
   let content: string;

--- a/tests/integration/cli/translate.test.ts
+++ b/tests/integration/cli/translate.test.ts
@@ -135,9 +135,13 @@ describe("Translate CLI Integration", () => {
       writeFileSync(inputPath, "# Test\n");
 
       const originalKey = process.env.ANTHROPIC_API_KEY;
+      const originalCwd = process.cwd();
       delete process.env.ANTHROPIC_API_KEY;
 
       try {
+        // Change to temp directory so loadConfig doesn't load .env from project root
+        process.chdir(tempDir);
+
         const result = await runCommand([
           "translate", "--input", inputPath, "--lang", "ja", "--config", configPath,
         ]);
@@ -145,6 +149,7 @@ describe("Translate CLI Integration", () => {
         expect(result.exitCode).not.toBe(0);
         expect(result.stderr).toMatch(/ANTHROPIC_API_KEY/i);
       } finally {
+        process.chdir(originalCwd);
         if (originalKey) process.env.ANTHROPIC_API_KEY = originalKey;
       }
     });

--- a/tests/unit/config/config.test.ts
+++ b/tests/unit/config/config.test.ts
@@ -78,15 +78,57 @@ describe("Config Loader", () => {
   });
 
   it("should load .env variables via dotenv", async () => {
-    const configPath = join(tempDir, "yuuhitsu.config.yaml");
-    const envPath = join(tempDir, ".env");
-    writeFileSync(configPath, `provider: claude\nmodel: claude-sonnet-4-5-20250929\n`);
-    writeFileSync(envPath, `ANTHROPIC_API_KEY=test-key-123\n`);
-
-    const config = await loadConfig(configPath, tempDir);
-    // dotenv should have loaded the env variable
-    expect(process.env.ANTHROPIC_API_KEY).toBe("test-key-123");
-    // Clean up
+    // Clean up any existing value first to avoid pollution from other tests
+    const originalValue = process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
+
+    try {
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      const envPath = join(tempDir, ".env");
+      writeFileSync(configPath, `provider: claude\nmodel: claude-sonnet-4-5-20250929\n`);
+      writeFileSync(envPath, `ANTHROPIC_API_KEY=test-key-123\n`);
+
+      const config = await loadConfig(configPath, tempDir);
+      // dotenv should have loaded the env variable
+      expect(process.env.ANTHROPIC_API_KEY).toBe("test-key-123");
+    } finally {
+      // Restore or clean up
+      if (originalValue) {
+        process.env.ANTHROPIC_API_KEY = originalValue;
+      } else {
+        delete process.env.ANTHROPIC_API_KEY;
+      }
+    }
+  });
+
+  it("should auto-load .env from cwd when envDir is not specified", async () => {
+    // Save original cwd and env value
+    const originalCwd = process.cwd();
+    const originalValue = process.env.TEST_AUTO_LOAD_KEY;
+    delete process.env.TEST_AUTO_LOAD_KEY;
+
+    // Change to temp directory
+    process.chdir(tempDir);
+
+    try {
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      const envPath = join(tempDir, ".env");
+      writeFileSync(configPath, `provider: claude\nmodel: claude-sonnet-4-5-20250929\n`);
+      writeFileSync(envPath, `TEST_AUTO_LOAD_KEY=auto-loaded-value\n`);
+
+      // Call loadConfig WITHOUT envDir parameter
+      const config = await loadConfig(configPath);
+
+      // The .env from cwd should be loaded automatically
+      expect(process.env.TEST_AUTO_LOAD_KEY).toBe("auto-loaded-value");
+    } finally {
+      // Restore original cwd and env value
+      process.chdir(originalCwd);
+      if (originalValue) {
+        process.env.TEST_AUTO_LOAD_KEY = originalValue;
+      } else {
+        delete process.env.TEST_AUTO_LOAD_KEY;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Modified `loadConfig()` to automatically load `.env` from current working directory when `envDir` parameter is not provided
- Fixes the issue where environment variables (like API keys) were not loaded when commands like `translate` called `loadConfig()` without `envDir`
- Added comprehensive test coverage for the new behavior
- Updated existing tests to properly isolate environment variables and avoid test pollution

## Technical Details

**Problem:**
Previously, `loadConfig()` only loaded `.env` when `envDir` was explicitly provided. The `translate` command (and potentially other commands) called `loadConfig(configPath)` without `envDir`, causing `.env` files to never be loaded. This meant API keys had to be set manually in the shell environment.

**Solution:**
```typescript
if (envDir) {
  dotenvConfig({ path: join(envDir, ".env") });
} else {
  dotenvConfig(); // Loads from cwd by default
}
```

This follows the principle of least surprise - users expect `.env` files in their working directory to be loaded automatically, similar to most Node.js tools with dotenv support.

## Test plan
- [x] Added new test: "should auto-load .env from cwd when envDir is not specified"
- [x] Updated existing tests to properly clean up environment variables
- [x] npm test PASS (39/39 tests passed, 0 skipped)
- [x] npm run lint PASS (no TypeScript errors)
- [x] Verified the fix resolves the original issue where .env was not loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable handling with fallback behavior. Configuration now automatically loads environment variables from the current working directory when envDir is not specified, while preserving existing behavior when a custom directory is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->