### PR TITLE
chore: add files field to limit npm tarball contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
   },
   "keywords": ["ai", "cli", "translation", "documentation"],
   "license": "MIT",
+  "files": [
+    "dist",
+    "src/templates",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@google/genai": "^0.7.0",


### PR DESCRIPTION
## Summary
- Add `files` field to package.json to limit npm tarball to essential files only
- Includes: dist/, src/templates/, README.md, LICENSE
- Excludes: .claude/, specs/, tests/, .specify/, .github/, .coderabbit.yaml, etc.
- Reduces package size from 109 files (300KB) to essential distribution files

## Test plan
- [ ] npm pack --dry-run shows only intended files
- [ ] npm test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to specify which files are included when publishing, ensuring only necessary project components and documentation are distributed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->