### PR TITLE
fix: use scoped package name @geolonia/yuuhitsu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yuuhitsu",
+  "name": "@geolonia/yuuhitsu",
   "version": "0.1.0",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Change package name from `yuuhitsu` to `@geolonia/yuuhitsu`
- Scoped under the Geolonia organization on npm

## Test plan
- [ ] npm test passes
- [ ] Package name is correctly scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package namespace to "@geolonia/yuuhitsu" to properly organize the package under the Geolonia scope. Users installing this package should reference the updated scoped name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->