### PR TITLE
feat: add init command for config generation

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,0 +1,95 @@
+import { Command } from "commander";
+import { writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import chalk from "chalk";
+
+const DEFAULT_CONFIG_TEMPLATE = `# Yuuhitsu Configuration File
+# AI-powered document operations CLI
+# See: https://github.com/geolonia/yuuhitsu
+
+# AI Provider Selection
+# Choose one: claude, gemini, or ollama
+provider: claude
+
+# Model Configuration
+# Claude models: claude-sonnet-4-5-20250929, claude-opus-4-6-20250929, claude-haiku-4-5-20251001
+# Gemini models: gemini-2.0-flash, gemini-1.5-pro
+# Ollama models: llama3.2, mistral, etc. (requires local Ollama server)
+model: claude-sonnet-4-5-20250929
+
+# Example configurations for other providers:
+#
+# --- Claude (Anthropic) ---
+# provider: claude
+# model: claude-sonnet-4-5-20250929
+# Requires: ANTHROPIC_API_KEY environment variable
+#
+# --- Gemini (Google) ---
+# provider: gemini
+# model: gemini-2.0-flash
+# Requires: GOOGLE_API_KEY environment variable
+#
+# --- Ollama (Local) ---
+# provider: ollama
+# model: llama3.2
+# Requires: Ollama server running locally (no API key needed)
+# Install: https://ollama.ai
+
+# Optional: Custom template directory
+# templates: ./templates
+
+# Optional: Default output directory
+# outputDir: ./output
+
+# Optional: Logging configuration
+# log:
+#   enabled: true
+#   path: ./yuuhitsu.log
+`;
+
+export const initCommand = new Command("init")
+  .description("Initialize a yuuhitsu config file")
+  .option("--force", "Overwrite existing config file")
+  .action(async (opts) => {
+    const configPath = join(process.cwd(), "yuuhitsu.config.yaml");
+
+    // Check if config already exists
+    if (existsSync(configPath) && !opts.force) {
+      process.stderr.write(
+        chalk.red("Error:") + " Config file already exists: " + configPath + "\n" +
+        chalk.yellow("Hint:") + " Use --force to overwrite the existing file\n"
+      );
+      process.exit(1);
+    }
+
+    // Write config file
+    try {
+      writeFileSync(configPath, DEFAULT_CONFIG_TEMPLATE, "utf-8");
+
+      if (opts.force && existsSync(configPath)) {
+        process.stdout.write(
+          chalk.green("✓") + " Config file overwritten: " + configPath + "\n"
+        );
+      } else {
+        process.stdout.write(
+          chalk.green("✓") + " Config file created: " + configPath + "\n"
+        );
+      }
+
+      process.stdout.write(
+        "\n" +
+        "Next steps:\n" +
+        "1. Set your API key:\n" +
+        "   - For Claude: export ANTHROPIC_API_KEY='your-key'\n" +
+        "   - For Gemini: export GOOGLE_API_KEY='your-key'\n" +
+        "   - For Ollama: Start Ollama server (ollama serve)\n" +
+        "2. Run a command: yuuhitsu translate --input file.md --lang ja\n"
+      );
+    } catch (err: unknown) {
+      process.stderr.write(
+        chalk.red("Error:") + " Failed to create config file\n" +
+        chalk.yellow("Hint:") + " " + (err instanceof Error ? err.message : String(err)) + "\n"
+      );
+      process.exit(1);
+    }
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { formatError } from "../errors.js";
 import { translateCommand } from "./commands/translate.js";
+import { initCommand } from "./commands/init.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -32,6 +33,7 @@ program
   .option("--verbose", "Enable verbose output");
 
 // Register commands
+program.addCommand(initCommand);
 program.addCommand(translateCommand);
 
 program.parseAsync(process.argv).catch((err) => {

--- a/tests/integration/cli/init.test.ts
+++ b/tests/integration/cli/init.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Command } from "commander";
+
+// We test the CLI by importing the init command directly
+import { initCommand } from "../../../src/cli/commands/init.js";
+
+describe("Init CLI Integration", () => {
+  let tempDir: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `yuuhitsu-init-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(tempDir);
+
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as any);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tempDir, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
+  function getOutput(): { stdout: string; stderr: string } {
+    const stdout = stdoutSpy.mock.calls.map(c => String(c[0])).join("");
+    const stderr = stderrSpy.mock.calls.map(c => String(c[0])).join("");
+    return { stdout, stderr };
+  }
+
+  async function runCommand(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    // Build a fresh parent program to provide global options
+    const program = new Command();
+    program
+      .option("--config <path>", "Config file path", "./yuuhitsu.config.yaml")
+      .option("--dry-run", "Show what would be done without making API calls")
+      .option("--verbose", "Enable verbose output");
+    program.addCommand(initCommand);
+
+    try {
+      await program.parseAsync(["node", "yuuhitsu", ...args]);
+      const out = getOutput();
+      return { ...out, exitCode: 0 };
+    } catch {
+      const out = getOutput();
+      return { ...out, exitCode: 1 };
+    }
+  }
+
+  describe("File generation", () => {
+    it("should create yuuhitsu.config.yaml in current directory", async () => {
+      const result = await runCommand(["init"]);
+
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      expect(existsSync(configPath)).toBe(true);
+      expect(result.exitCode).toBe(0);
+
+      const content = readFileSync(configPath, "utf-8");
+      // Should contain commented examples for all providers
+      expect(content).toMatch(/provider:/);
+      expect(content).toMatch(/model:/);
+      expect(content).toMatch(/claude/i);
+      expect(content).toMatch(/gemini/i);
+      expect(content).toMatch(/ollama/i);
+    });
+
+    it("should output success message", async () => {
+      const result = await runCommand(["init"]);
+
+      expect(result.stdout).toMatch(/created|generated|initialized/i);
+      expect(result.stdout).toMatch(/yuuhitsu\.config\.yaml/);
+    });
+  });
+
+  describe("Existing file detection", () => {
+    it("should show error when config file already exists", async () => {
+      // Create existing config
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      writeFileSync(configPath, "provider: claude\nmodel: test\n");
+
+      const result = await runCommand(["init"]);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(/already exists|overwrite/i);
+    });
+
+    it("should suggest --force flag when file exists", async () => {
+      // Create existing config
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      writeFileSync(configPath, "provider: claude\nmodel: test\n");
+
+      const result = await runCommand(["init"]);
+
+      expect(result.stderr).toMatch(/--force/);
+    });
+  });
+
+  describe("--force flag", () => {
+    it("should overwrite existing file when --force is used", async () => {
+      // Create existing config with custom content
+      const configPath = join(tempDir, "yuuhitsu.config.yaml");
+      const originalContent = "provider: claude\nmodel: old-model\n";
+      writeFileSync(configPath, originalContent);
+
+      const result = await runCommand(["init", "--force"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(configPath)).toBe(true);
+
+      const newContent = readFileSync(configPath, "utf-8");
+      // Should be replaced with template content
+      expect(newContent).not.toBe(originalContent);
+      expect(newContent).toMatch(/claude/i);
+      expect(newContent).toMatch(/gemini/i);
+      expect(newContent).toMatch(/ollama/i);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implemented `yuuhitsu init` command to generate default configuration file
- Generates `yuuhitsu.config.yaml` with commented examples for Claude, Gemini, and Ollama
- Includes safety check for existing files with `--force` override option
- Provides clear setup instructions after config creation

## Features
- **Config Template**: Comprehensive YAML template with examples for all supported providers
- **Safety Check**: Prevents accidental overwrite of existing config (unless `--force` is used)
- **Setup Guidance**: Shows next steps including API key setup instructions
- **Provider Examples**: Includes configuration examples and requirements for:
  - Claude (requires ANTHROPIC_API_KEY)
  - Gemini (requires GOOGLE_API_KEY)
  - Ollama (requires local server, no API key)

## Test plan
- [x] File generation in current directory
- [x] Existing file detection with clear error message
- [x] `--force` flag for overwriting existing config
- [x] npm test PASS (44/44 tests, 0 SKIP)
- [x] npm run lint PASS (no TypeScript errors)
- [x] Test-first development: tests written before implementation

## Test Coverage
- 5 new integration tests in `tests/integration/cli/init.test.ts`
- All tests follow test-first approach (FAIL → implement → PASS)
- Coverage includes success and error scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `init` CLI command to initialize a default configuration file with pre-configured AI provider settings.
  * Added `--force` flag to overwrite existing configuration during initialization.
  * Init command provides helpful next-steps guidance upon successful setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->