### PR TITLE
fix: preserve frontmatter and links during translation

### DIFF
--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -4,6 +4,30 @@ import type { AIProvider, ChatMessage } from "../provider/interface.js";
 
 const CHUNK_SIZE = 50 * 1024; // 50KB
 
+interface FrontmatterSeparation {
+  frontmatter: string | null;
+  body: string;
+}
+
+/**
+ * Separate frontmatter from Markdown content
+ * @param content - Full Markdown content
+ * @returns Object with separated frontmatter and body
+ */
+export function separateFrontmatter(content: string): FrontmatterSeparation {
+  // Match frontmatter pattern: ---\n...\n---\n
+  const frontmatterRegex = /^---\n([\s\S]*?)\n---\n/;
+  const match = content.match(frontmatterRegex);
+
+  if (match) {
+    const frontmatter = match[0]; // Including --- delimiters
+    const body = content.slice(match[0].length);
+    return { frontmatter, body };
+  }
+
+  return { frontmatter: null, body: content };
+}
+
 export interface TranslateOptions {
   provider: AIProvider;
   inputPath: string;
@@ -30,6 +54,14 @@ Rules:
 - Do not translate frontmatter keys (only translate values where appropriate)
 - Maintain the same document structure
 - Produce natural, fluent text in the target language
+
+CRITICAL - Link and URL preservation:
+- NEVER modify any URLs or link paths. Keep all href/src values exactly as-is.
+- NEVER change internal link paths (e.g., /ja/..., /en/..., ./relative-path). Preserve them verbatim.
+- NEVER convert external URLs to different language versions.
+- If the source has [text](/ja/changelog), the output must keep the same path, only translate the link text if needed.
+- Example: [紹介](/ja/intro) → translate "紹介" but keep "/ja/intro" unchanged
+- Example: [MDN](https://developer.mozilla.org/ja/) → keep the /ja/ in URL, translate "MDN" if needed
 
 Additional rules for Japanese translation:
 - Use full-width punctuation: 。、？！ (not .,?!)
@@ -116,8 +148,11 @@ export async function translateFile(
   // Ensure output directory exists
   mkdirSync(dirname(resolvedOutput), { recursive: true });
 
-  // Split into chunks if needed
-  const chunks = splitIntoChunks(content);
+  // Separate frontmatter from body
+  const { frontmatter, body } = separateFrontmatter(content);
+
+  // Split body into chunks if needed (frontmatter is never sent to LLM)
+  const chunks = splitIntoChunks(body);
   const translatedParts: string[] = [];
   let totalUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 
@@ -134,7 +169,12 @@ export async function translateFile(
     totalUsage.totalTokens += response.usage.totalTokens;
   }
 
-  const translatedContent = translatedParts.join("");
+  const translatedBody = translatedParts.join("");
+
+  // Recombine frontmatter with translated body
+  const translatedContent = frontmatter
+    ? frontmatter + translatedBody
+    : translatedBody;
 
   // Write output
   writeFileSync(resolvedOutput, translatedContent, "utf-8");

--- a/src/templates/translate.md
+++ b/src/templates/translate.md
@@ -7,6 +7,14 @@ Rules:
 - Maintain the same document structure
 - Produce natural, fluent text in the target language
 
+CRITICAL - Link and URL preservation:
+- NEVER modify any URLs or link paths. Keep all href/src values exactly as-is.
+- NEVER change internal link paths (e.g., /ja/..., /en/..., ./relative-path). Preserve them verbatim.
+- NEVER convert external URLs to different language versions.
+- If the source has [text](/ja/changelog), the output must keep the same path, only translate the link text if needed.
+- Example: [紹介](/ja/intro) → translate "紹介" but keep "/ja/intro" unchanged
+- Example: [MDN](https://developer.mozilla.org/ja/) → keep the /ja/ in URL, translate "MDN" if needed
+
 Additional rules for Japanese translation:
 - Use full-width punctuation: 。、？！ (not .,?!)
 - Add half-width spaces around English words and numbers (e.g., "Vela とは", "NGSIv2 は", "3 つの")

--- a/tests/unit/tasks/translate-preserve.test.ts
+++ b/tests/unit/tasks/translate-preserve.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { translateFile } from "../../../src/tasks/translate.js";
+import type { AIProvider, ChatCompletionResponse } from "../../../src/provider/interface.js";
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("Translation preservation (frontmatter & links)", () => {
+  let mockProvider: AIProvider;
+  let tempDir: string;
+  let mockChat: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `yuuhitsu-preserve-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    mockChat = vi.fn<any, Promise<ChatCompletionResponse>>();
+    mockProvider = {
+      name: "mock",
+      chat: mockChat,
+    };
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("Frontmatter preservation", () => {
+    it("should preserve frontmatter exactly as-is during translation", async () => {
+      const inputContent = `---
+title: 変更履歴
+description: リリースノート
+layout: default
+---
+
+# Changelog
+
+This is the changelog.`;
+
+      const translatedBody = `# 変更履歴
+
+これは変更履歴です。`;
+
+      mockChat.mockResolvedValue({
+        content: translatedBody,
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+      });
+
+      const inputPath = join(tempDir, "test.md");
+      const outputPath = join(tempDir, "test.ja.md");
+
+      writeFileSync(inputPath, inputContent, "utf-8");
+
+      await translateFile({
+        provider: mockProvider,
+        inputPath,
+        outputPath,
+        targetLang: "ja",
+      });
+
+      const output = readFileSync(outputPath, "utf-8");
+
+      // Frontmatter should be preserved exactly
+      expect(output).toContain("---\ntitle: 変更履歴\ndescription: リリースノート\nlayout: default\n---");
+
+      // Body should be translated
+      expect(output).toContain("# 変更履歴");
+      expect(output).toContain("これは変更履歴です。");
+
+      // LLM should NOT receive frontmatter
+      const callArg = mockChat.mock.calls[0][0];
+      const userMessage = callArg.messages.find((m: any) => m.role === "user");
+      expect(userMessage.content).not.toContain("title: 変更履歴");
+      expect(userMessage.content).toContain("# Changelog");
+    });
+
+    it("should handle files without frontmatter normally", async () => {
+      const inputContent = `# Introduction
+
+This is a document without frontmatter.`;
+
+      const translatedContent = `# はじめに
+
+これはfrontmatterのないドキュメントです。`;
+
+      mockChat.mockResolvedValue({
+        content: translatedContent,
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+      });
+
+      const inputPath = join(tempDir, "test.md");
+      const outputPath = join(tempDir, "test.ja.md");
+
+      writeFileSync(inputPath, inputContent, "utf-8");
+
+      await translateFile({
+        provider: mockProvider,
+        inputPath,
+        outputPath,
+        targetLang: "ja",
+      });
+
+      const output = readFileSync(outputPath, "utf-8");
+
+      expect(output).toBe(translatedContent);
+
+      // LLM should receive full content
+      const callArg = mockChat.mock.calls[0][0];
+      const userMessage = callArg.messages.find((m: any) => m.role === "user");
+      expect(userMessage.content).toContain("# Introduction");
+    });
+  });
+
+  describe("Internal link preservation", () => {
+    it("should preserve internal link paths and only translate link text", async () => {
+      const inputContent = `Check the [introduction guide](/ja/introduction/quick-start) for details.
+
+Also see [this page](./relative-path/guide.md).`;
+
+      const translatedContent = `詳細については[紹介ガイド](/ja/introduction/quick-start)を確認してください。
+
+また、[このページ](./relative-path/guide.md)も参照してください。`;
+
+      mockChat.mockResolvedValue({
+        content: translatedContent,
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+      });
+
+      const inputPath = join(tempDir, "test.md");
+      const outputPath = join(tempDir, "test.ja.md");
+
+      writeFileSync(inputPath, inputContent, "utf-8");
+
+      await translateFile({
+        provider: mockProvider,
+        inputPath,
+        outputPath,
+        targetLang: "ja",
+      });
+
+      const output = readFileSync(outputPath, "utf-8");
+
+      // Link paths must be preserved exactly
+      expect(output).toContain("/ja/introduction/quick-start");
+      expect(output).toContain("./relative-path/guide.md");
+
+      // Link text should be translated
+      expect(output).toContain("紹介ガイド");
+      expect(output).toContain("このページ");
+    });
+  });
+
+  describe("External URL preservation", () => {
+    it("should preserve external URLs exactly without language conversion", async () => {
+      const inputContent = `Visit [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) for the Japanese version.
+
+Also check [MDN](https://developer.mozilla.org/ja/docs/Web/) for Japanese docs.`;
+
+      const translatedContent = `日本語版については、[Keep a Changelog](https://keepachangelog.com/ja/1.1.0/)を参照してください。
+
+また、日本語ドキュメントは[MDN](https://developer.mozilla.org/ja/docs/Web/)を確認してください。`;
+
+      mockChat.mockResolvedValue({
+        content: translatedContent,
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+      });
+
+      const inputPath = join(tempDir, "test.md");
+      const outputPath = join(tempDir, "test.ja.md");
+
+      writeFileSync(inputPath, inputContent, "utf-8");
+
+      await translateFile({
+        provider: mockProvider,
+        inputPath,
+        outputPath,
+        targetLang: "en",
+      });
+
+      const output = readFileSync(outputPath, "utf-8");
+
+      // URLs must be preserved exactly (no /ja/ -> /en/ conversion)
+      expect(output).toContain("https://keepachangelog.com/ja/1.1.0/");
+      expect(output).toContain("https://developer.mozilla.org/ja/docs/Web/");
+
+      // Link text should be translated
+      expect(output).toContain("日本語版については");
+      expect(output).toContain("日本語ドキュメント");
+    });
+  });
+
+  describe("Combined: frontmatter + links", () => {
+    it("should preserve both frontmatter and links in the same document", async () => {
+      const inputContent = `---
+title: Introduction
+url: /ja/intro
+---
+
+# Introduction
+
+See [quick start](/ja/quick-start) and visit [our site](https://example.com/ja/).`;
+
+      const translatedBody = `# はじめに
+
+[クイックスタート](/ja/quick-start)を参照し、[当サイト](https://example.com/ja/)をご覧ください。`;
+
+      mockChat.mockResolvedValue({
+        content: translatedBody,
+        usage: { promptTokens: 10, completionTokens: 10, totalTokens: 20 },
+      });
+
+      const inputPath = join(tempDir, "test.md");
+      const outputPath = join(tempDir, "test.ja.md");
+
+      writeFileSync(inputPath, inputContent, "utf-8");
+
+      await translateFile({
+        provider: mockProvider,
+        inputPath,
+        outputPath,
+        targetLang: "ja",
+      });
+
+      const output = readFileSync(outputPath, "utf-8");
+
+      // Frontmatter preserved
+      expect(output).toContain("title: Introduction");
+      expect(output).toContain("url: /ja/intro");
+
+      // Links preserved
+      expect(output).toContain("/ja/quick-start");
+      expect(output).toContain("https://example.com/ja/");
+
+      // Text translated
+      expect(output).toContain("はじめに");
+      expect(output).toContain("クイックスタート");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes three translation quality issues (Q001, Q002, Q003) identified in subtask_048a:

**Fixed Issues:**
- **Q001**: Frontmatter values no longer get translated (e.g., `title: 変更履歴` stays unchanged)
- **Q002**: Internal link paths are preserved (e.g., `/ja/...` paths remain `/ja/...`)
- **Q003**: External URLs are preserved exactly (e.g., Japanese URLs stay Japanese)

**Solution Approach:**
1. **Logic improvement**: Added `separateFrontmatter()` function to extract YAML frontmatter before sending to LLM
2. **Prompt enhancement**: Added CRITICAL link/URL preservation rules to both `translate.ts` and `translate.md`
3. **Test coverage**: Created comprehensive test suite (`translate-preserve.test.ts`) with 5 test cases

**Implementation Details:**
- `separateFrontmatter()` uses regex pattern `/^---\n([\s\S]*?)\n---\n/` to extract frontmatter
- `translateFile()` now processes: separate frontmatter → translate body only → recombine
- Template consistency ensured between `DEFAULT_TEMPLATE` and `translate.md`

## Test Plan

- [x] All 5 new preservation tests pass
- [x] Full test suite passes (74 tests, 9 files) - no regressions
- [x] TypeScript lint passes with no errors
- [ ] CodeRabbit review pending
- [ ] Manual verification with real translation scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation now preserves document frontmatter (metadata headers) unchanged in output
  * Enhanced link and URL preservation rules to keep paths intact while translating link text
  * Added option to specify custom output file paths during translation
  * Improved Japanese translation guidelines covering punctuation style and technical terminology

* **Tests**
  * Added comprehensive unit test suite validating translation preservation features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->