### PR TITLE
feat: Glossary機能実装（init/check/sync/review + translate拡張）

### DIFF
--- a/src/cli/commands/glossary.ts
+++ b/src/cli/commands/glossary.ts
@@ -1,0 +1,143 @@
+import { Command } from "commander";
+import { writeFileSync } from "fs";
+import { resolve } from "path";
+import chalk from "chalk";
+import {
+  initGlossary,
+  checkGlossary,
+  syncGlossary,
+  reviewGlossary,
+} from "../../tasks/glossary.js";
+import { formatError } from "../../errors.js";
+
+// ---------------------------------------------------------------------------
+// glossary init
+// ---------------------------------------------------------------------------
+
+const initCmd = new Command("init")
+  .description("Generate a glossary.yaml skeleton")
+  .option("--output <path>", "Output path for glossary file", "glossary.yaml")
+  .option("--force", "Overwrite existing glossary file")
+  .action(async (opts) => {
+    const outputPath = resolve(process.cwd(), opts.output);
+    try {
+      initGlossary(outputPath, opts.force || undefined);
+      process.stdout.write(
+        `${chalk.green("✓")} Glossary file created: ${outputPath}\n`
+      );
+    } catch (err: unknown) {
+      process.stderr.write(formatError(err) + "\n");
+      process.exit(1);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// glossary check
+// ---------------------------------------------------------------------------
+
+const checkCmd = new Command("check")
+  .description("Detect terminology inconsistencies in a document")
+  .requiredOption("--input <file>", "Document file to check")
+  .requiredOption("--glossary <path>", "Glossary file path")
+  .requiredOption("--lang <code>", "Language code to check (e.g., ja, en)")
+  .action(async (opts) => {
+    try {
+      const issues = checkGlossary(opts.input, opts.glossary, opts.lang);
+
+      if (issues.length === 0) {
+        process.stdout.write(
+          `${chalk.green("✓")} No issues found in ${opts.input}\n`
+        );
+        return;
+      }
+
+      process.stdout.write(
+        `${chalk.yellow("⚠")} Found ${issues.length} terminology issue(s) in ${opts.input}:\n\n`
+      );
+
+      for (const issue of issues) {
+        process.stdout.write(
+          `  Line ${issue.line}: "${chalk.red(issue.forbidden)}" → use "${chalk.green(issue.canonical)}"\n`
+        );
+      }
+    } catch (err: unknown) {
+      process.stderr.write(formatError(err) + "\n");
+      process.exit(1);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// glossary sync
+// ---------------------------------------------------------------------------
+
+const syncCmd = new Command("sync")
+  .description("Sync glossary with translation files and report coverage")
+  .requiredOption("--glossary <path>", "Glossary file path")
+  .action(async (opts) => {
+    try {
+      const result = syncGlossary(opts.glossary);
+
+      process.stdout.write(
+        `${chalk.green("✓")} Glossary sync report\n\n` +
+        `  Total terms: ${result.totalTerms}\n`
+      );
+
+      for (const [lang, terms] of Object.entries(result.termsByLanguage)) {
+        process.stdout.write(
+          `  ${lang}: ${terms.length} / ${result.totalTerms} terms translated\n`
+        );
+      }
+
+      if (result.missingTranslations.length > 0) {
+        process.stdout.write(
+          `\n${chalk.yellow("⚠")} Missing translations:\n`
+        );
+        for (const missing of result.missingTranslations) {
+          process.stdout.write(
+            `  "${missing.canonical}" missing: ${missing.missingLanguages.join(", ")}\n`
+          );
+        }
+      }
+    } catch (err: unknown) {
+      process.stderr.write(formatError(err) + "\n");
+      process.exit(1);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// glossary review
+// ---------------------------------------------------------------------------
+
+const reviewCmd = new Command("review")
+  .description("Generate a glossary review report")
+  .requiredOption("--glossary <path>", "Glossary file path")
+  .option("--output <path>", "Save report to file (Markdown)")
+  .action(async (opts) => {
+    try {
+      const report = reviewGlossary(opts.glossary);
+      const markdown = report.toMarkdown();
+
+      if (opts.output) {
+        writeFileSync(opts.output, markdown, "utf-8");
+        process.stdout.write(
+          `${chalk.green("✓")} Review report saved to ${opts.output}\n`
+        );
+      } else {
+        process.stdout.write(markdown);
+      }
+    } catch (err: unknown) {
+      process.stderr.write(formatError(err) + "\n");
+      process.exit(1);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// glossary (parent command)
+// ---------------------------------------------------------------------------
+
+export const glossaryCommand = new Command("glossary")
+  .description("Manage glossary for terminology consistency")
+  .addCommand(initCmd)
+  .addCommand(checkCmd)
+  .addCommand(syncCmd)
+  .addCommand(reviewCmd);

--- a/src/cli/commands/glossary.ts
+++ b/src/cli/commands/glossary.ts
@@ -60,6 +60,7 @@ const checkCmd = new Command("check")
           `  Line ${issue.line}: "${chalk.red(issue.forbidden)}" → use "${chalk.green(issue.canonical)}"\n`
         );
       }
+      process.exit(1);
     } catch (err: unknown) {
       process.stderr.write(formatError(err) + "\n");
       process.exit(1);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { formatError } from "../errors.js";
 import { translateCommand } from "./commands/translate.js";
 import { initCommand } from "./commands/init.js";
+import { glossaryCommand } from "./commands/glossary.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -35,6 +36,7 @@ program
 // Register commands
 program.addCommand(initCommand);
 program.addCommand(translateCommand);
+program.addCommand(glossaryCommand);
 
 program.parseAsync(process.argv).catch((err) => {
   process.stderr.write(formatError(err) + "\n");

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,12 @@ export async function loadConfig(
 
   if (raw.templates) config.templates = raw.templates;
   if (raw.outputDir) config.outputDir = raw.outputDir;
-  if (raw.glossary) config.glossary = raw.glossary;
+  if (raw.glossary !== undefined) {
+    if (typeof raw.glossary !== "string") {
+      throw new Error('Config field "glossary" must be a string path');
+    }
+    config.glossary = raw.glossary;
+  }
   if (raw.log) {
     config.log = {
       enabled: raw.log.enabled ?? false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export interface AppConfig {
   model: string;
   templates?: string;
   outputDir?: string;
+  glossary?: string;
   log?: {
     enabled?: boolean;
     path?: string;
@@ -63,6 +64,7 @@ export async function loadConfig(
 
   if (raw.templates) config.templates = raw.templates;
   if (raw.outputDir) config.outputDir = raw.outputDir;
+  if (raw.glossary) config.glossary = raw.glossary;
   if (raw.log) {
     config.log = {
       enabled: raw.log.enabled ?? false,

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -1,0 +1,278 @@
+import { readFileSync, writeFileSync, existsSync } from "fs";
+import { parse } from "yaml";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface GlossaryTerm {
+  canonical: string;
+  type: string;
+  translations: Record<string, string>;
+  do_not_use?: Record<string, string[]>;
+}
+
+export interface GlossaryConfig {
+  version: number;
+  languages: string[];
+  terms: GlossaryTerm[];
+}
+
+export interface GlossaryIssue {
+  forbidden: string;
+  canonical: string;
+  line: number;
+}
+
+export interface MissingTranslation {
+  canonical: string;
+  missingLanguages: string[];
+}
+
+export interface SyncResult {
+  totalTerms: number;
+  termsByLanguage: Record<string, GlossaryTerm[]>;
+  missingTranslations: MissingTranslation[];
+}
+
+export interface ReviewReport {
+  terms: GlossaryTerm[];
+  summary: {
+    totalTerms: number;
+    languages: string[];
+  };
+  toMarkdown(): string;
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton template
+// ---------------------------------------------------------------------------
+
+const SKELETON_TEMPLATE = `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+    do_not_use:
+      ja: ["ＡＰＩ", "えーぴーあい"]
+  # Add more terms below:
+  # - canonical: "webhook"
+  #   type: noun
+  #   translations:
+  #     ja: "Webhook"
+  #     en: "webhook"
+  #   do_not_use:
+  #     ja: ["ウェブフック"]
+  #     en: ["web hook"]
+`;
+
+// ---------------------------------------------------------------------------
+// loadGlossary
+// ---------------------------------------------------------------------------
+
+export function loadGlossary(glossaryPath: string): GlossaryConfig | null {
+  if (!existsSync(glossaryPath)) {
+    return null;
+  }
+
+  const content = readFileSync(glossaryPath, "utf-8");
+  const raw = parse(content);
+
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`Invalid glossary file: ${glossaryPath}`);
+  }
+
+  return raw as GlossaryConfig;
+}
+
+// ---------------------------------------------------------------------------
+// initGlossary
+// ---------------------------------------------------------------------------
+
+export function initGlossary(outputPath: string, force?: boolean): void {
+  if (existsSync(outputPath) && !force) {
+    throw new Error(
+      `Glossary file already exists: ${outputPath}\nUse --force to overwrite.`
+    );
+  }
+
+  writeFileSync(outputPath, SKELETON_TEMPLATE, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// checkGlossary
+// ---------------------------------------------------------------------------
+
+export function checkGlossary(
+  docPath: string,
+  glossaryPath: string,
+  lang: string
+): GlossaryIssue[] {
+  // Load glossary (throws if not found)
+  const glossary = loadGlossary(glossaryPath);
+  if (!glossary) {
+    throw new Error(`Glossary file not found: ${glossaryPath}`);
+  }
+
+  // Read document (throws if not found)
+  let docContent: string;
+  try {
+    docContent = readFileSync(docPath, "utf-8");
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as any).code === "ENOENT") {
+      throw new Error(`Document not found: ${docPath}`);
+    }
+    throw err;
+  }
+
+  const lines = docContent.split("\n");
+  const issues: GlossaryIssue[] = [];
+
+  for (const term of glossary.terms) {
+    const forbidden = term.do_not_use?.[lang] ?? [];
+    for (const forbiddenWord of forbidden) {
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes(forbiddenWord)) {
+          issues.push({
+            forbidden: forbiddenWord,
+            canonical: term.canonical,
+            line: i + 1,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// syncGlossary
+// ---------------------------------------------------------------------------
+
+export function syncGlossary(glossaryPath: string): SyncResult {
+  const glossary = loadGlossary(glossaryPath);
+  if (!glossary) {
+    throw new Error(`Glossary file not found: ${glossaryPath}`);
+  }
+
+  const termsByLanguage: Record<string, GlossaryTerm[]> = {};
+  for (const lang of glossary.languages) {
+    termsByLanguage[lang] = [];
+  }
+
+  const missingTranslations: MissingTranslation[] = [];
+
+  for (const term of glossary.terms) {
+    const missingLangs: string[] = [];
+
+    for (const lang of glossary.languages) {
+      if (term.translations[lang]) {
+        termsByLanguage[lang].push(term);
+      } else {
+        missingLangs.push(lang);
+      }
+    }
+
+    if (missingLangs.length > 0) {
+      missingTranslations.push({
+        canonical: term.canonical,
+        missingLanguages: missingLangs,
+      });
+    }
+  }
+
+  return {
+    totalTerms: glossary.terms.length,
+    termsByLanguage,
+    missingTranslations,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// reviewGlossary
+// ---------------------------------------------------------------------------
+
+export function reviewGlossary(glossaryPath: string): ReviewReport {
+  const glossary = loadGlossary(glossaryPath);
+  if (!glossary) {
+    throw new Error(`Glossary file not found: ${glossaryPath}`);
+  }
+
+  const report: ReviewReport = {
+    terms: glossary.terms,
+    summary: {
+      totalTerms: glossary.terms.length,
+      languages: glossary.languages,
+    },
+    toMarkdown(): string {
+      const lines: string[] = [
+        "# Glossary Review Report",
+        "",
+        `**Total Terms:** ${glossary.terms.length}`,
+        `**Languages:** ${glossary.languages.join(", ")}`,
+        "",
+        "## Terms",
+        "",
+      ];
+
+      for (const term of glossary.terms) {
+        lines.push(`### ${term.canonical}`);
+        lines.push("");
+        lines.push(`- **Type:** ${term.type}`);
+        lines.push("- **Translations:**");
+        for (const [lang, translation] of Object.entries(term.translations)) {
+          lines.push(`  - \`${lang}\`: ${translation}`);
+        }
+        if (term.do_not_use && Object.keys(term.do_not_use).length > 0) {
+          lines.push("- **Do not use:**");
+          for (const [lang, words] of Object.entries(term.do_not_use)) {
+            lines.push(`  - \`${lang}\`: ${words.join(", ")}`);
+          }
+        }
+        lines.push("");
+      }
+
+      return lines.join("\n");
+    },
+  };
+
+  return report;
+}
+
+// ---------------------------------------------------------------------------
+// buildGlossaryPrompt — helper for translate integration
+// ---------------------------------------------------------------------------
+
+export function buildGlossaryPrompt(
+  glossaryConfig: GlossaryConfig,
+  targetLang: string
+): string {
+  const relevantTerms = glossaryConfig.terms.filter(
+    (t) => t.translations[targetLang] || t.do_not_use?.[targetLang]
+  );
+
+  if (relevantTerms.length === 0) {
+    return "";
+  }
+
+  const lines: string[] = [
+    "",
+    "Glossary — use these canonical translations and avoid forbidden terms:",
+  ];
+
+  for (const term of relevantTerms) {
+    const canonical = term.translations[targetLang] ?? term.canonical;
+    const forbidden = term.do_not_use?.[targetLang] ?? [];
+    let line = `- "${term.canonical}" → "${canonical}"`;
+    if (forbidden.length > 0) {
+      line += ` (do NOT use: ${forbidden.map((f) => `"${f}"`).join(", ")})`;
+    }
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}

--- a/tests/unit/cli/glossary-command.test.ts
+++ b/tests/unit/cli/glossary-command.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Mock tasks to avoid file system side effects in CLI tests
+vi.mock("../../../src/tasks/glossary.js", () => ({
+  initGlossary: vi.fn(),
+  checkGlossary: vi.fn().mockReturnValue([]),
+  syncGlossary: vi.fn().mockReturnValue({
+    totalTerms: 2,
+    termsByLanguage: { ja: [], en: [] },
+    missingTranslations: [],
+  }),
+  reviewGlossary: vi.fn().mockReturnValue({
+    terms: [],
+    summary: { totalTerms: 0, languages: [] },
+    toMarkdown: vi.fn().mockReturnValue("# Glossary Review\n"),
+  }),
+  loadGlossary: vi.fn().mockReturnValue(null),
+}));
+
+import { glossaryCommand } from "../../../src/cli/commands/glossary.js";
+import { initGlossary, checkGlossary, syncGlossary, reviewGlossary } from "../../../src/tasks/glossary.js";
+
+describe("Glossary CLI Command", () => {
+  let tempDir: string;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `yuuhitsu-glossary-cli-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  describe("glossary command structure", () => {
+    it("should have 'glossary' as command name", () => {
+      expect(glossaryCommand.name()).toBe("glossary");
+    });
+
+    it("should have init subcommand", () => {
+      const subcommands = glossaryCommand.commands.map((c) => c.name());
+      expect(subcommands).toContain("init");
+    });
+
+    it("should have check subcommand", () => {
+      const subcommands = glossaryCommand.commands.map((c) => c.name());
+      expect(subcommands).toContain("check");
+    });
+
+    it("should have sync subcommand", () => {
+      const subcommands = glossaryCommand.commands.map((c) => c.name());
+      expect(subcommands).toContain("sync");
+    });
+
+    it("should have review subcommand", () => {
+      const subcommands = glossaryCommand.commands.map((c) => c.name());
+      expect(subcommands).toContain("review");
+    });
+  });
+
+  describe("glossary init subcommand", () => {
+    it("should call initGlossary with default path", async () => {
+      const initCmd = glossaryCommand.commands.find((c) => c.name() === "init")!;
+      await initCmd.parseAsync([], { from: "user" });
+      expect(initGlossary).toHaveBeenCalledWith(
+        expect.stringContaining("glossary.yaml"),
+        undefined
+      );
+    });
+
+    it("should call initGlossary with --output path", async () => {
+      const outputPath = join(tempDir, "custom-glossary.yaml");
+      const initCmd = glossaryCommand.commands.find((c) => c.name() === "init")!;
+      await initCmd.parseAsync(["--output", outputPath], { from: "user" });
+      expect(initGlossary).toHaveBeenCalledWith(outputPath, undefined);
+    });
+
+    it("should pass force flag when --force is specified", async () => {
+      const initCmd = glossaryCommand.commands.find((c) => c.name() === "init")!;
+      await initCmd.parseAsync(["--force"], { from: "user" });
+      expect(initGlossary).toHaveBeenCalledWith(
+        expect.stringContaining("glossary.yaml"),
+        true
+      );
+    });
+
+    it("should print success message on init", async () => {
+      const initCmd = glossaryCommand.commands.find((c) => c.name() === "init")!;
+      await initCmd.parseAsync([], { from: "user" });
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("glossary.yaml");
+    });
+  });
+
+  describe("glossary check subcommand", () => {
+    it("should require --input option", async () => {
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+
+      await expect(
+        checkCmd.parseAsync([], { from: "user" })
+      ).rejects.toThrow();
+
+      exitSpy.mockRestore();
+    });
+
+    it("should call checkGlossary with correct arguments", async () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja, en]\nterms: []\n");
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await checkCmd.parseAsync(
+        ["--input", docPath, "--glossary", glossaryPath, "--lang", "en"],
+        { from: "user" }
+      );
+      expect(checkGlossary).toHaveBeenCalledWith(docPath, glossaryPath, "en");
+    });
+
+    it("should print 'no issues' when check returns empty array", async () => {
+      vi.mocked(checkGlossary).mockReturnValue([]);
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await checkCmd.parseAsync(
+        ["--input", docPath, "--glossary", glossaryPath, "--lang", "ja"],
+        { from: "user" }
+      );
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toMatch(/no issues|✓/i);
+    });
+
+    it("should print issues when found", async () => {
+      vi.mocked(checkGlossary).mockReturnValue([
+        { forbidden: "ＡＰＩ", canonical: "API", line: 3 },
+      ]);
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await checkCmd.parseAsync(
+        ["--input", docPath, "--glossary", glossaryPath, "--lang", "ja"],
+        { from: "user" }
+      );
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("ＡＰＩ");
+    });
+  });
+
+  describe("glossary sync subcommand", () => {
+    it("should call syncGlossary with glossary path", async () => {
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const syncCmd = glossaryCommand.commands.find((c) => c.name() === "sync")!;
+      await syncCmd.parseAsync(["--glossary", glossaryPath], { from: "user" });
+      expect(syncGlossary).toHaveBeenCalledWith(glossaryPath);
+    });
+
+    it("should print sync result", async () => {
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const syncCmd = glossaryCommand.commands.find((c) => c.name() === "sync")!;
+      await syncCmd.parseAsync(["--glossary", glossaryPath], { from: "user" });
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toMatch(/term|sync/i);
+    });
+  });
+
+  describe("glossary review subcommand", () => {
+    it("should call reviewGlossary with glossary path", async () => {
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const reviewCmd = glossaryCommand.commands.find((c) => c.name() === "review")!;
+      await reviewCmd.parseAsync(["--glossary", glossaryPath], { from: "user" });
+      expect(reviewGlossary).toHaveBeenCalledWith(glossaryPath);
+    });
+
+    it("should print Markdown report", async () => {
+      vi.mocked(reviewGlossary).mockReturnValue({
+        terms: [],
+        summary: { totalTerms: 0, languages: [] },
+        toMarkdown: vi.fn().mockReturnValue("# Glossary Review\n\n0 terms.\n"),
+      });
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const reviewCmd = glossaryCommand.commands.find((c) => c.name() === "review")!;
+      await reviewCmd.parseAsync(["--glossary", glossaryPath], { from: "user" });
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("Glossary Review");
+    });
+
+    it("should save report to --output file when specified", async () => {
+      const outputPath = join(tempDir, "report.md");
+      vi.mocked(reviewGlossary).mockReturnValue({
+        terms: [],
+        summary: { totalTerms: 0, languages: [] },
+        toMarkdown: vi.fn().mockReturnValue("# Glossary Review\n"),
+      });
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja]\nterms: []\n");
+
+      const reviewCmd = glossaryCommand.commands.find((c) => c.name() === "review")!;
+      await reviewCmd.parseAsync(
+        ["--glossary", glossaryPath, "--output", outputPath],
+        { from: "user" }
+      );
+
+      const { existsSync, readFileSync } = await import("fs");
+      expect(existsSync(outputPath)).toBe(true);
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content).toContain("Glossary Review");
+    });
+  });
+});

--- a/tests/unit/config/config.test.ts
+++ b/tests/unit/config/config.test.ts
@@ -66,6 +66,15 @@ describe("Config Loader", () => {
     await expect(loadConfig(configPath)).rejects.toThrow(/model/i);
   });
 
+  it("should throw when glossary field is not a string", async () => {
+    const configPath = join(tempDir, "yuuhitsu.config.yaml");
+    writeFileSync(
+      configPath,
+      `provider: claude\nmodel: claude-sonnet-4-5-20250929\nglossary:\n  path: glossary.yaml\n`
+    );
+    await expect(loadConfig(configPath)).rejects.toThrow(/glossary.*string/i);
+  });
+
   it("should load optional log configuration", async () => {
     const configPath = join(tempDir, "yuuhitsu.config.yaml");
     writeFileSync(

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  initGlossary,
+  checkGlossary,
+  syncGlossary,
+  reviewGlossary,
+  loadGlossary,
+} from "../../../src/tasks/glossary.js";
+
+describe("Glossary Tasks", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `yuuhitsu-glossary-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // ---------------------------------------------------------------------------
+  // loadGlossary
+  // ---------------------------------------------------------------------------
+  describe("loadGlossary", () => {
+    it("should load a valid glossary.yaml", () => {
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(
+        glossaryPath,
+        `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+    do_not_use:
+      ja: ["ＡＰＩ", "えーぴーあい"]
+`
+      );
+
+      const glossary = loadGlossary(glossaryPath);
+      expect(glossary).not.toBeNull();
+      expect(glossary!.version).toBe(1);
+      expect(glossary!.languages).toEqual(["ja", "en"]);
+      expect(glossary!.terms).toHaveLength(1);
+      expect(glossary!.terms[0].canonical).toBe("API");
+      expect(glossary!.terms[0].translations.ja).toBe("API");
+      expect(glossary!.terms[0].do_not_use?.ja).toEqual([
+        "ＡＰＩ",
+        "えーぴーあい",
+      ]);
+    });
+
+    it("should return null when file does not exist", () => {
+      const glossary = loadGlossary(join(tempDir, "nonexistent.yaml"));
+      expect(glossary).toBeNull();
+    });
+
+    it("should throw when glossary file is invalid YAML", () => {
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "{ invalid: yaml: content:");
+      expect(() => loadGlossary(glossaryPath)).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // initGlossary
+  // ---------------------------------------------------------------------------
+  describe("initGlossary", () => {
+    it("should create a glossary.yaml skeleton", () => {
+      const outputPath = join(tempDir, "glossary.yaml");
+      initGlossary(outputPath);
+
+      expect(existsSync(outputPath)).toBe(true);
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content).toContain("version:");
+      expect(content).toContain("languages:");
+      expect(content).toContain("terms:");
+      expect(content).toContain("canonical:");
+    });
+
+    it("should include example term in skeleton", () => {
+      const outputPath = join(tempDir, "glossary.yaml");
+      initGlossary(outputPath);
+
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content).toContain("do_not_use:");
+      expect(content).toContain("translations:");
+    });
+
+    it("should throw when file already exists without force", () => {
+      const outputPath = join(tempDir, "glossary.yaml");
+      writeFileSync(outputPath, "existing content");
+
+      expect(() => initGlossary(outputPath)).toThrow(/already exists/i);
+    });
+
+    it("should overwrite existing file with force=true", () => {
+      const outputPath = join(tempDir, "glossary.yaml");
+      writeFileSync(outputPath, "old content");
+
+      initGlossary(outputPath, true);
+
+      const content = readFileSync(outputPath, "utf-8");
+      expect(content).toContain("version:");
+      expect(content).not.toBe("old content");
+    });
+
+    it("should create the glossary as parseable YAML", () => {
+      const outputPath = join(tempDir, "glossary.yaml");
+      initGlossary(outputPath);
+
+      const glossary = loadGlossary(outputPath);
+      expect(glossary).not.toBeNull();
+      expect(glossary!.version).toBe(1);
+      expect(Array.isArray(glossary!.languages)).toBe(true);
+      expect(Array.isArray(glossary!.terms)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // checkGlossary
+  // ---------------------------------------------------------------------------
+  describe("checkGlossary", () => {
+    let glossaryPath: string;
+
+    beforeEach(() => {
+      glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(
+        glossaryPath,
+        `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+    do_not_use:
+      ja: ["ＡＰＩ", "えーぴーあい"]
+  - canonical: "webhook"
+    type: noun
+    translations:
+      ja: "Webhook"
+      en: "webhook"
+    do_not_use:
+      ja: ["ウェブフック"]
+      en: ["web hook", "Web Hook"]
+`
+      );
+    });
+
+    it("should return no issues for a clean document", () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# API Documentation\n\nThis is about the API and Webhook.\n");
+
+      const issues = checkGlossary(docPath, glossaryPath, "en");
+      expect(issues).toHaveLength(0);
+    });
+
+    it("should detect do_not_use terms in Japanese document", () => {
+      const docPath = join(tempDir, "doc.ja.md");
+      writeFileSync(
+        docPath,
+        "# ＡＰＩドキュメント\n\nこれはＡＰＩとウェブフックについてのドキュメントです。\n"
+      );
+
+      const issues = checkGlossary(docPath, glossaryPath, "ja");
+      expect(issues.length).toBeGreaterThan(0);
+
+      const issueTerms = issues.map((i) => i.forbidden);
+      expect(issueTerms).toContain("ＡＰＩ");
+      expect(issueTerms).toContain("ウェブフック");
+    });
+
+    it("should detect do_not_use terms in English document", () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Documentation\n\nUse web hook instead of webhook.\n");
+
+      const issues = checkGlossary(docPath, glossaryPath, "en");
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues[0].forbidden).toBe("web hook");
+    });
+
+    it("should include line number in issue", () => {
+      const docPath = join(tempDir, "doc.ja.md");
+      writeFileSync(docPath, "# Title\n\nＡＰＩの説明\n");
+
+      const issues = checkGlossary(docPath, glossaryPath, "ja");
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues[0].line).toBe(3);
+    });
+
+    it("should include suggested canonical term in issue", () => {
+      const docPath = join(tempDir, "doc.ja.md");
+      writeFileSync(docPath, "えーぴーあいを使ってください。\n");
+
+      const issues = checkGlossary(docPath, glossaryPath, "ja");
+      expect(issues.length).toBeGreaterThan(0);
+      expect(issues[0].canonical).toBe("API");
+    });
+
+    it("should throw when glossary file does not exist", () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "some content");
+
+      expect(() =>
+        checkGlossary(docPath, join(tempDir, "nonexistent.yaml"), "en")
+      ).toThrow();
+    });
+
+    it("should throw when document file does not exist", () => {
+      expect(() =>
+        checkGlossary(join(tempDir, "nonexistent.md"), glossaryPath, "en")
+      ).toThrow(/not found|ENOENT/i);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // syncGlossary
+  // ---------------------------------------------------------------------------
+  describe("syncGlossary", () => {
+    let glossaryPath: string;
+
+    beforeEach(() => {
+      glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(
+        glossaryPath,
+        `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+  - canonical: "webhook"
+    type: noun
+    translations:
+      ja: "Webhook"
+      en: "webhook"
+`
+      );
+    });
+
+    it("should return a sync result with term coverage", () => {
+      const result = syncGlossary(glossaryPath);
+      expect(result).toHaveProperty("totalTerms");
+      expect(result).toHaveProperty("termsByLanguage");
+      expect(result.totalTerms).toBe(2);
+    });
+
+    it("should list terms for each language", () => {
+      const result = syncGlossary(glossaryPath);
+      expect(result.termsByLanguage).toHaveProperty("ja");
+      expect(result.termsByLanguage).toHaveProperty("en");
+      expect(result.termsByLanguage.ja).toHaveLength(2);
+      expect(result.termsByLanguage.en).toHaveLength(2);
+    });
+
+    it("should detect missing translations", () => {
+      const glossaryPath2 = join(tempDir, "glossary-partial.yaml");
+      writeFileSync(
+        glossaryPath2,
+        `version: 1
+languages: [ja, en, zh]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+`
+      );
+
+      const result = syncGlossary(glossaryPath2);
+      expect(result.missingTranslations).toBeDefined();
+      expect(result.missingTranslations.length).toBeGreaterThan(0);
+      const missing = result.missingTranslations.find(
+        (m) => m.canonical === "API"
+      );
+      expect(missing).toBeDefined();
+      expect(missing!.missingLanguages).toContain("zh");
+    });
+
+    it("should throw when glossary file does not exist", () => {
+      expect(() =>
+        syncGlossary(join(tempDir, "nonexistent.yaml"))
+      ).toThrow();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // reviewGlossary
+  // ---------------------------------------------------------------------------
+  describe("reviewGlossary", () => {
+    let glossaryPath: string;
+
+    beforeEach(() => {
+      glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(
+        glossaryPath,
+        `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "API"
+    type: noun
+    translations:
+      ja: "API"
+      en: "API"
+    do_not_use:
+      ja: ["ＡＰＩ"]
+  - canonical: "webhook"
+    type: noun
+    translations:
+      ja: "Webhook"
+      en: "webhook"
+`
+      );
+    });
+
+    it("should generate a review report with all terms", () => {
+      const report = reviewGlossary(glossaryPath);
+      expect(report).toHaveProperty("terms");
+      expect(report.terms).toHaveLength(2);
+    });
+
+    it("should include term details in report", () => {
+      const report = reviewGlossary(glossaryPath);
+      const apiTerm = report.terms.find((t) => t.canonical === "API");
+      expect(apiTerm).toBeDefined();
+      expect(apiTerm!.type).toBe("noun");
+      expect(apiTerm!.translations.ja).toBe("API");
+    });
+
+    it("should include do_not_use in report", () => {
+      const report = reviewGlossary(glossaryPath);
+      const apiTerm = report.terms.find((t) => t.canonical === "API");
+      expect(apiTerm!.do_not_use?.ja).toContain("ＡＰＩ");
+    });
+
+    it("should include summary statistics in report", () => {
+      const report = reviewGlossary(glossaryPath);
+      expect(report).toHaveProperty("summary");
+      expect(report.summary.totalTerms).toBe(2);
+      expect(report.summary.languages).toEqual(["ja", "en"]);
+    });
+
+    it("should throw when glossary file does not exist", () => {
+      expect(() =>
+        reviewGlossary(join(tempDir, "nonexistent.yaml"))
+      ).toThrow();
+    });
+
+    it("should format report as Markdown string", () => {
+      const report = reviewGlossary(glossaryPath);
+      const md = report.toMarkdown();
+      expect(typeof md).toBe("string");
+      expect(md).toContain("API");
+      expect(md).toContain("webhook");
+      expect(md).toContain("#");
+    });
+  });
+});

--- a/tests/unit/tasks/translate-glossary.test.ts
+++ b/tests/unit/tasks/translate-glossary.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { translateFile } from "../../../src/tasks/translate.js";
+import type { GlossaryConfig } from "../../../src/tasks/glossary.js";
+
+function createMockProvider(responseContent: string) {
+  return {
+    chat: vi.fn().mockResolvedValue({
+      content: responseContent,
+      model: "mock-model",
+      usage: { promptTokens: 100, completionTokens: 200, totalTokens: 300 },
+      finishReason: "end_turn",
+    }),
+    chatStream: vi.fn(),
+  };
+}
+
+describe("Translate Task - Glossary Integration", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `yuuhitsu-translate-glossary-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const sampleGlossary: GlossaryConfig = {
+    version: 1,
+    languages: ["ja", "en"],
+    terms: [
+      {
+        canonical: "API",
+        type: "noun",
+        translations: { ja: "API", en: "API" },
+        do_not_use: { ja: ["ＡＰＩ", "えーぴーあい"] },
+      },
+      {
+        canonical: "webhook",
+        type: "noun",
+        translations: { ja: "Webhook", en: "webhook" },
+        do_not_use: { ja: ["ウェブフック"] },
+      },
+    ],
+  };
+
+  it("should include glossary term instructions in system prompt", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# API Reference\n\nThis document describes the API.\n");
+
+    const mockProvider = createMockProvider("# APIリファレンス\n\nこのドキュメントはAPIについて説明します。\n");
+
+    await translateFile({
+      provider: mockProvider,
+      inputPath,
+      outputPath,
+      targetLang: "ja",
+      glossaryConfig: sampleGlossary,
+    });
+
+    expect(mockProvider.chat).toHaveBeenCalledTimes(1);
+    const callArgs = mockProvider.chat.mock.calls[0][0];
+    const systemMsg = callArgs.messages.find((m: any) => m.role === "system");
+    expect(systemMsg).toBeDefined();
+    // Glossary instructions should appear in system prompt
+    expect(systemMsg.content).toContain("API");
+    expect(systemMsg.content).toContain("ＡＰＩ");
+  });
+
+  it("should include do_not_use terms for target language in prompt", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Webhook Guide\n");
+
+    const mockProvider = createMockProvider("# Webhookガイド\n");
+
+    await translateFile({
+      provider: mockProvider,
+      inputPath,
+      outputPath,
+      targetLang: "ja",
+      glossaryConfig: sampleGlossary,
+    });
+
+    const callArgs = mockProvider.chat.mock.calls[0][0];
+    const systemMsg = callArgs.messages.find((m: any) => m.role === "system");
+    expect(systemMsg.content).toContain("ウェブフック");
+    expect(systemMsg.content).toContain("Webhook");
+  });
+
+  it("should not add glossary instructions when glossaryConfig is undefined", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Test\n");
+
+    const mockProvider = createMockProvider("# テスト\n");
+
+    await translateFile({
+      provider: mockProvider,
+      inputPath,
+      outputPath,
+      targetLang: "ja",
+      // no glossaryConfig
+    });
+
+    const callArgs = mockProvider.chat.mock.calls[0][0];
+    const systemMsg = callArgs.messages.find((m: any) => m.role === "system");
+    // Without glossary, should not contain specific glossary section keywords
+    expect(systemMsg.content).not.toContain("Glossary");
+    expect(systemMsg.content).not.toContain("do_not_use");
+  });
+
+  it("should use canonical translation for target language in prompt", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Test\n");
+
+    const mockProvider = createMockProvider("# テスト\n");
+
+    await translateFile({
+      provider: mockProvider,
+      inputPath,
+      outputPath,
+      targetLang: "ja",
+      glossaryConfig: sampleGlossary,
+    });
+
+    const callArgs = mockProvider.chat.mock.calls[0][0];
+    const systemMsg = callArgs.messages.find((m: any) => m.role === "system");
+    // Canonical translation for ja should appear
+    expect(systemMsg.content).toContain("Webhook");
+  });
+});


### PR DESCRIPTION
## Summary
- glossary.yaml スキーマ定義（version, languages, terms, do_not_use）
- `yuuhitsu glossary init/check/sync/review` サブコマンド追加
- `yuuhitsu translate` の glossary 参照・用語統一拡張（`glossaryConfig` オプション）
- `yuuhitsu.config.yaml` に glossary フィールド追加

Closes #14

## Test plan
- [x] `yuuhitsu glossary init` でスケルトン生成を確認
- [x] `yuuhitsu glossary check` で用語不統一検出を確認（ja/en 両言語）
- [x] `yuuhitsu glossary sync` で翻訳カバレッジ確認
- [x] `yuuhitsu glossary review` で Markdown レポート生成確認
- [x] 全ユニットテスト PASS (132件、SKIP=0)
- [x] TypeCheck / Lint PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a glossary management system with four CLI commands: initialize glossaries, check documents for terminology compliance, sync translations, and generate review reports.
  * Integrated glossary support into translation workflows and added optional glossary configuration.

* **Tests**
  * Added comprehensive unit tests covering glossary commands, core glossary tasks, translation integration, and config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->