### PR TITLE
fix(glossary): skip code blocks, inline code, URLs, and frontmatter in checkGlossary

### DIFF
--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -54,10 +54,12 @@ export function protectCodeBlocks(content: string): CodeProtection {
 
   // Step 1: Replace fenced code blocks (4+ backticks before 3-backtick blocks)
   // Matches ````+ ... ```` or ``` ... ``` (non-greedy, multiline)
+  // Preserve the original line count by repeating newlines so subsequent line numbers stay correct.
   let result = content.replace(/(`{3,})[^\n]*\n[\s\S]*?\1[ \t]*(\n|$)/g, (match) => {
     const placeholder = `__CODE_BLOCK_${blockIndex++}__`;
     map.set(placeholder, match);
-    return placeholder + "\n";
+    const newlineCount = (match.match(/\n/g) ?? []).length;
+    return placeholder + "\n".repeat(newlineCount);
   });
 
   // Step 2: Replace inline code (single backtick, not within code blocks)

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -303,6 +303,18 @@ terms:
         const issues = checkGlossary(docPath, fpGlossaryPath, "en");
         expect(issues).toHaveLength(0);
       });
+
+      it("should preserve line numbers for violations after fenced code blocks", () => {
+        const docPath = join(tempDir, "doc-line-map.md");
+        writeFileSync(
+          docPath,
+          "```\nweb hook in code\n```\n\nThis hook should be flagged.\n"
+        );
+        const issues = checkGlossary(docPath, fpGlossaryPath, "en");
+        expect(issues).toHaveLength(1);
+        expect(issues[0].forbidden).toBe("hook");
+        expect(issues[0].line).toBe(5);
+      });
     });
   });
 

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -245,6 +245,65 @@ terms:
         checkGlossary(docPath, glossaryPath, "zh")
       ).toThrow(/not defined in glossary/i);
     });
+
+    describe("false positive suppression", () => {
+      let fpGlossaryPath: string;
+
+      beforeEach(() => {
+        fpGlossaryPath = join(tempDir, "glossary-fp.yaml");
+        writeFileSync(
+          fpGlossaryPath,
+          `version: 1
+languages: [en]
+terms:
+  - canonical: "webhook"
+    type: noun
+    translations:
+      en: "webhook"
+    do_not_use:
+      en: ["web hook", "hook"]
+`
+        );
+      });
+
+      it("should not flag forbidden words inside fenced code blocks", () => {
+        const docPath = join(tempDir, "doc-fenced.md");
+        writeFileSync(
+          docPath,
+          "Text before.\n\n```\nweb hook example\n```\n\nText after.\n"
+        );
+        const issues = checkGlossary(docPath, fpGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden words inside inline code", () => {
+        const docPath = join(tempDir, "doc-inline.md");
+        writeFileSync(docPath, "Use `web hook` syntax here.\n");
+        const issues = checkGlossary(docPath, fpGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden words inside URLs", () => {
+        const docPath = join(tempDir, "doc-url.md");
+        writeFileSync(
+          docPath,
+          "See [docs](https://example.com/hook-events/list) for info.\n"
+        );
+        // "hook" appears inside URL https://example.com/hook-events/list but should not be flagged
+        const issues = checkGlossary(docPath, fpGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden words inside frontmatter", () => {
+        const docPath = join(tempDir, "doc-fm.md");
+        writeFileSync(
+          docPath,
+          "---\ntitle: web hook reference guide\n---\n\nBody is clean.\n"
+        );
+        const issues = checkGlossary(docPath, fpGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `checkGlossary` がコードブロック・インラインコード・URL・frontmatter 内のテキストを誤検出する不具合を修正
- `translate.ts` の `separateFrontmatter` / `protectCodeBlocks` を import して再利用
- URL 内テキストは `https?://\S+` パターンで除去してからチェック

## Changes

- `src/tasks/glossary.ts`: `checkGlossary` 関数に false positive 抑制ロジックを追加
- `tests/unit/tasks/glossary.test.ts`: 4ケースのテストを追加（fenced code block / inline code / URL / frontmatter）

## Test Results

141 tests passed (0 skipped)

Closes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glossary scanning to avoid false positives by excluding code blocks, inline code, URLs, and frontmatter.
  * Preserved accurate issue line numbers by accounting for frontmatter and maintaining original line counts during content protection.

* **Tests**
  * Added tests covering false positive suppression and verification of correct line-number reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->