### PR TITLE
fix(glossary): suppress false positives when do_not_use term is substring of canonical translation

### DIFF
--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -159,6 +159,7 @@ export function checkGlossary(
     const forbidden = term.do_not_use?.[lang] ?? [];
     const canonicalTranslation = term.translations[lang];
     for (const forbiddenWord of forbidden) {
+      if (forbiddenWord.length === 0) continue;
       for (let i = 0; i < lines.length; i++) {
         // Remove URL content before checking to avoid false positives inside URLs
         const lineWithoutUrls = lines[i].replace(/https?:\/\/\S+/g, "");
@@ -221,6 +222,7 @@ function hasUncoveredOccurrence(
   forbiddenWord: string,
   canonicalTranslation: string | undefined
 ): boolean {
+  if (forbiddenWord.length === 0) return false;
   let searchPos = 0;
   while (true) {
     const idx = line.indexOf(forbiddenWord, searchPos);

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -361,7 +361,7 @@ terms:
         const docPath = join(tempDir, "doc-substr3.md");
         writeFileSync(docPath, "サブスク管理画面を開きます。\n");
         const issues = checkGlossary(docPath, substrGlossaryPath, "ja");
-        expect(issues.length).toBeGreaterThan(0);
+        expect(issues).toHaveLength(1);
         expect(issues[0].forbidden).toBe("サブスク");
       });
 
@@ -369,7 +369,7 @@ terms:
         const docPath = join(tempDir, "doc-substr4.md");
         writeFileSync(docPath, "ブローカーに接続します。\n");
         const issues = checkGlossary(docPath, substrGlossaryPath, "ja");
-        expect(issues.length).toBeGreaterThan(0);
+        expect(issues).toHaveLength(1);
         expect(issues[0].forbidden).toBe("ブローカー");
       });
 
@@ -382,7 +382,7 @@ terms:
           "サブスクリプションとサブスクの違いを説明します。\n"
         );
         const issues = checkGlossary(docPath, substrGlossaryPath, "ja");
-        expect(issues.length).toBeGreaterThan(0);
+        expect(issues).toHaveLength(1);
         expect(issues[0].forbidden).toBe("サブスク");
       });
     });


### PR DESCRIPTION
## 問題

`checkGlossary` が `line.includes(forbiddenWord)` でサブストリングマッチを行うため、canonical 翻訳に `do_not_use` 用語が含まれる場合に誤検出が発生していた。

- `サブスクリプション`（正しい canonical ja） → `サブスク`（do_not_use）を含むため誤検出
- `コンテキストブローカー`（正しい canonical ja） → `ブローカー`（do_not_use variant）を含むため誤検出

## 修正内容

最長マッチ優先アプローチを採用:

1. `do_not_use` 用語のマッチ位置を特定
2. その位置が同一 glossary エントリの canonical 翻訳（`translations[lang]`）の一部であるかチェック
3. canonical 翻訳の一部であれば → 違反としない（false positive 除去）
4. canonical 翻訳の一部でなければ → 従来通り違反として報告

## 追加テスト（テストファースト）

- `サブスクリプション` テキスト → `サブスク` do_not_use → 違反なし ✅
- `コンテキストブローカー` テキスト → `ブローカー` do_not_use → 違反なし ✅
- `サブスク管理` → `サブスク` 単独 → 違反あり ✅
- `ブローカーに接続` → `ブローカー` 単独 → 違反あり ✅
- canonical と do_not_use が同一行 → standalone のみ検出 ✅

## テスト結果

```
Tests  147 passed (147)
```

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glossary validation to avoid false positives when forbidden substrings appear inside longer approved translations; only true standalone violations are now reported.

* **Tests**
  * Added unit tests covering substring match scenarios to verify forbidden terms are flagged only when standalone and not when embedded within canonical translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->