### PR TITLE
feat(glossary): add JSON i18n file support

### DIFF
--- a/src/cli/commands/glossary.ts
+++ b/src/cli/commands/glossary.ts
@@ -56,8 +56,9 @@ const checkCmd = new Command("check")
       );
 
       for (const issue of issues) {
+        const location = issue.keyPath ? issue.keyPath : `Line ${issue.line}`;
         process.stdout.write(
-          `  Line ${issue.line}: "${chalk.red(issue.forbidden)}" → use "${chalk.green(issue.canonical)}"\n`
+          `  ${location}: "${chalk.red(issue.forbidden)}" → use "${chalk.green(issue.canonical)}"\n`
         );
       }
       process.exit(1);


### PR DESCRIPTION
## Summary

- JSON ファイル（`.json` 拡張子）をパースし、全 string value を再帰的に抽出して glossary check を適用
- 違反報告に行番号の代わり JSON キーパス（例: `dashboard.title`、`items[1]`）を使用
- value 内 URL は除外（既存の Markdown モードと同様）
- Markdown モードの既存機能に影響なし（既存テスト全 PASS 維持）

## Test plan

- [x] フラットな JSON の value チェック
- [x] ネストされたオブジェクトの再帰チェック
- [x] 配列内の文字列チェック（ブラケット記法: `items[1]`）
- [x] 空文字列・null・数値等の非文字列 value のスキップ
- [x] JSON 内 URL 除外
- [x] 無効な JSON ファイルのエラースロー
- [x] 既存 Markdown チェックが壊れないこと（163 tests PASS）

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Glossary checking now supports JSON files, automatically validating string values in nested objects and arrays.

* **Bug Fixes**
  * Enhanced error reporting with precise location information for violations in both JSON and text documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->