### PR TITLE
fix(glossary): skip technical identifiers and URN patterns in check

### DIFF
--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -167,10 +167,11 @@ export function checkGlossary(
       for (const forbiddenWord of forbidden) {
         if (forbiddenWord.length === 0) continue;
         for (const { keyPath, value } of stringValues) {
-          // Remove URL content before checking to avoid false positives inside URLs
+          // Remove URL/URN content before checking to avoid false positives
           const valueWithoutUrls = value
             .replace(/https?:\/\/\S+/g, "")
-            .replace(/\]\([^)]+\)/g, "");
+            .replace(/\]\([^)]+\)/g, "")
+            .replace(/urn:\S+/g, "");
           if (hasUncoveredOccurrence(valueWithoutUrls, forbiddenWord, canonicalTranslation)) {
             issues.push({
               forbidden: forbiddenWord,
@@ -202,10 +203,11 @@ export function checkGlossary(
     for (const forbiddenWord of forbidden) {
       if (forbiddenWord.length === 0) continue;
       for (let i = 0; i < lines.length; i++) {
-        // Remove URL content before checking to avoid false positives inside URLs
+        // Remove URL/URN content before checking to avoid false positives
         const lineWithoutUrls = lines[i]
           .replace(/https?:\/\/\S+/g, "")
-          .replace(/\]\([^)]+\)/g, "");
+          .replace(/\]\([^)]+\)/g, "")
+          .replace(/urn:\S+/g, "");
         if (hasUncoveredOccurrence(lineWithoutUrls, forbiddenWord, canonicalTranslation)) {
           issues.push({
             forbidden: forbiddenWord,
@@ -295,8 +297,34 @@ function isOccurrenceCoveredByCanonical(
 }
 
 /**
+ * Returns true if the match at `matchIdx` is part of a larger technical
+ * identifier (e.g., "NGSILD" in "NGSILD-Warning" or "API_NGSILD.md").
+ *
+ * Uses ASCII identifier characters to detect compound words:
+ * - Before: [a-zA-Z0-9_] (alphanumeric + underscore)
+ * - After:  [a-zA-Z0-9_\-] (alphanumeric + underscore + hyphen for compound words)
+ */
+function isPartOfLargerIdentifier(
+  line: string,
+  matchIdx: number,
+  matchLen: number
+): boolean {
+  if (matchIdx > 0) {
+    const charBefore = line[matchIdx - 1];
+    if (/[a-zA-Z0-9_]/.test(charBefore)) return true;
+  }
+  const afterIdx = matchIdx + matchLen;
+  if (afterIdx < line.length) {
+    const charAfter = line[afterIdx];
+    if (/[a-zA-Z0-9_\-]/.test(charAfter)) return true;
+  }
+  return false;
+}
+
+/**
  * Returns true if `line` contains at least one occurrence of `forbiddenWord`
- * that is NOT covered by `canonicalTranslation` appearing at the same position.
+ * that is NOT covered by `canonicalTranslation` appearing at the same position
+ * and is NOT part of a larger technical identifier.
  */
 function hasUncoveredOccurrence(
   line: string,
@@ -308,7 +336,10 @@ function hasUncoveredOccurrence(
   while (true) {
     const idx = line.indexOf(forbiddenWord, searchPos);
     if (idx === -1) break;
-    if (!isOccurrenceCoveredByCanonical(line, idx, forbiddenWord, canonicalTranslation)) {
+    if (
+      !isOccurrenceCoveredByCanonical(line, idx, forbiddenWord, canonicalTranslation) &&
+      !isPartOfLargerIdentifier(line, idx, forbiddenWord.length)
+    ) {
       return true;
     }
     searchPos = idx + 1;

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -402,6 +402,120 @@ terms:
       });
     });
 
+    describe("technical identifier boundary detection", () => {
+      let techGlossaryPath: string;
+
+      beforeEach(() => {
+        techGlossaryPath = join(tempDir, "glossary-tech.yaml");
+        writeFileSync(
+          techGlossaryPath,
+          `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "NGSI-LD"
+    type: brand
+    translations:
+      ja: "NGSI-LD"
+      en: "NGSI-LD"
+    do_not_use:
+      ja: ["NGSILD", "ngsi-ld"]
+      en: ["NGSILD", "ngsi-ld"]
+  - canonical: "GeonicDB"
+    type: brand
+    translations:
+      ja: "GeonicDB"
+      en: "GeonicDB"
+    do_not_use:
+      ja: ["geonicdb"]
+      en: ["geonicdb"]
+`
+        );
+      });
+
+      it("should not flag forbidden word inside hyphenated compound (NGSILD-Warning)", () => {
+        const docPath = join(tempDir, "doc-compound.md");
+        writeFileSync(
+          docPath,
+          "| Warning header (NGSILD-Warning) | description |\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden word inside underscore identifier (API_NGSILD.md)", () => {
+        const docPath = join(tempDir, "doc-ident.md");
+        writeFileSync(
+          docPath,
+          "See API_NGSILD.md for NGSI-LD API details.\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden word in markdown link text that is a filename", () => {
+        const docPath = join(tempDir, "doc-linktext.md");
+        writeFileSync(
+          docPath,
+          "[API_NGSILD.md](./ngsild.md) - NGSI-LD API reference\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden word inside URN pattern (urn:ngsi-ld:null)", () => {
+        const docPath = join(tempDir, "doc-urn.md");
+        writeFileSync(
+          docPath,
+          "| supports merge-patch+json, urn:ngsi-ld:null, keyValues |\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag forbidden word in compound package name (geonicdb-cli)", () => {
+        const docPath = join(tempDir, "doc-package.md");
+        writeFileSync(
+          docPath,
+          "Source: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should still flag standalone forbidden word", () => {
+        const docPath = join(tempDir, "doc-standalone.md");
+        writeFileSync(
+          docPath,
+          "Use NGSILD for testing.\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(1);
+        expect(issues[0].forbidden).toBe("NGSILD");
+      });
+
+      it("should still flag forbidden word at end of sentence", () => {
+        const docPath = join(tempDir, "doc-endsentence.md");
+        writeFileSync(
+          docPath,
+          "This uses NGSILD.\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(1);
+        expect(issues[0].forbidden).toBe("NGSILD");
+      });
+
+      it("should still flag standalone lowercase forbidden word", () => {
+        const docPath = join(tempDir, "doc-lower.md");
+        writeFileSync(
+          docPath,
+          "Use geonicdb for this project.\n"
+        );
+        const issues = checkGlossary(docPath, techGlossaryPath, "en");
+        expect(issues).toHaveLength(1);
+        expect(issues[0].forbidden).toBe("geonicdb");
+      });
+    });
+
     describe("substring match false positive suppression", () => {
       let substrGlossaryPath: string;
 


### PR DESCRIPTION
## Summary

- Add word-boundary detection (`isPartOfLargerIdentifier`) to avoid false positives when forbidden words appear inside compound technical identifiers (e.g., `API_NGSILD.md`, `NGSILD-Warning`, `geonicdb-cli`)
- Add URN pattern stripping (`urn:\S+`) alongside existing URL stripping to handle patterns like `urn:ngsi-ld:null`
- Standalone forbidden words are still correctly flagged

## Test plan

- [x] 8 new tests covering: hyphenated compounds, underscore identifiers, markdown link filenames, URN patterns, package names, and standalone detection
- [x] All 171 tests pass (63 glossary tests)
- [x] Verified against geonicdb-docs synced files: 0/40 violations (was 5/40)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced forbidden term detection in glossary scanning to recognize technical identifiers and compound words, reducing false positives in both JSON and Markdown formats.
  * Improved handling of URLs and URNs during glossary content analysis.

* **Tests**
  * Added comprehensive test coverage for glossary boundary detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->