### PR TITLE
fix(translate): replace regex code block detection with line-by-line parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-## [Unreleased]
+## [0.1.7] - 2026-03-10
+
+### Fixed
+- Replace regex-based code block detection with line-by-line parser to prevent V8 stack overflow on files with many fenced code blocks (e.g., NGSI-LD API docs with 100+ code blocks)
+- The previous regex `/(`{3,})[^\n]*\n[\s\S]*?\1/g` used backreference + non-greedy `[\s\S]*?` which caused recursive backtracking in V8, exceeding stack limits on CI runners
+
+### Added
+- Test for `protectCodeBlocks` robustness with many code blocks (ngsild.md pattern)
+- Test for unclosed code fence handling
+
+## [0.1.6] - 2026-03-09
 
 ### Added
 - Heading-based chunk splitting for `translateFile`: content is now split at `##` Markdown heading boundaries instead of fixed 50 KB byte boundaries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",
   "bin": {

--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -46,22 +46,54 @@ interface CodeProtection {
 
 /**
  * Replace fenced code blocks and inline code with placeholders.
- * Fenced blocks (``` or ````+) take priority over inline code.
+ * Uses a line-by-line parser instead of regex to avoid V8 stack overflow
+ * on files with many code blocks (backreference + [\s\S]*? causes recursive backtracking).
  */
 export function protectCodeBlocks(content: string): CodeProtection {
   const map = new Map<string, string>();
   let blockIndex = 0;
   let inlineIndex = 0;
 
-  // Step 1: Replace fenced code blocks (4+ backticks before 3-backtick blocks)
-  // Matches ````+ ... ```` or ``` ... ``` (non-greedy, multiline)
-  // Preserve the original line count by repeating newlines so subsequent line numbers stay correct.
-  let result = content.replace(/(`{3,})[^\n]*\n[\s\S]*?\1[ \t]*(\n|$)/g, (match) => {
-    const placeholder = `__CODE_BLOCK_${blockIndex++}__`;
-    map.set(placeholder, match);
-    const newlineCount = (match.match(/\n/g) ?? []).length;
-    return placeholder + "\n".repeat(newlineCount);
-  });
+  // Step 1: Replace fenced code blocks using line-by-line parsing
+  const lines = content.split("\n");
+  const resultLines: string[] = [];
+  let fenceOpen: string | null = null; // the backtick sequence that opened the current block
+  let blockLines: string[] = [];
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^(`{3,})/);
+
+    if (fenceOpen === null) {
+      // Not inside a code block
+      if (fenceMatch) {
+        // Opening fence found
+        fenceOpen = fenceMatch[1];
+        blockLines = [line];
+      } else {
+        resultLines.push(line);
+      }
+    } else {
+      // Inside a code block — look for closing fence with same or more backticks
+      blockLines.push(line);
+      if (fenceMatch && fenceMatch[1].length >= fenceOpen.length && line.trim() === fenceMatch[1]) {
+        // Closing fence found
+        const original = blockLines.join("\n") + "\n";
+        const placeholder = `__CODE_BLOCK_${blockIndex++}__`;
+        map.set(placeholder, original);
+        const newlineCount = blockLines.length; // lines inside block = newlines to preserve
+        resultLines.push(placeholder + "\n".repeat(newlineCount - 1));
+        fenceOpen = null;
+        blockLines = [];
+      }
+    }
+  }
+
+  // If we ended inside an unclosed fence, emit lines as-is
+  if (fenceOpen !== null) {
+    resultLines.push(...blockLines);
+  }
+
+  let result = resultLines.join("\n");
 
   // Step 2: Replace inline code (single backtick, not within code blocks)
   result = result.replace(/`([^`\n]+)`/g, (match) => {

--- a/tests/unit/tasks/translate-codeblock.test.ts
+++ b/tests/unit/tasks/translate-codeblock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { translateFile, separateFrontmatter } from "../../../src/tasks/translate.js";
+import { translateFile, separateFrontmatter, protectCodeBlocks } from "../../../src/tasks/translate.js";
 import type { AIProvider, ChatCompletionResponse } from "../../../src/provider/interface.js";
 import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "fs";
 import { join } from "path";
@@ -215,6 +215,43 @@ describe("Code block protection", () => {
     expect(output).toContain("````markdown");
     expect(output).toContain("const x = 1;");
     expect(output).not.toContain("__CODE_BLOCK_0__");
+  });
+});
+
+describe("protectCodeBlocks robustness", () => {
+  it("should handle many code blocks without stack overflow (ngsild.md pattern)", () => {
+    // protectCodeBlocks imported at top level
+
+    // Simulate ngsild.md: many short code blocks (http + json) interleaved with text/tables
+    const blocks: string[] = ["# NGSI-LD API\n"];
+    for (let i = 0; i < 50; i++) {
+      blocks.push(`## Section ${i}\n`);
+      blocks.push("```http\nGET /api/v1/entities\n```\n");
+      blocks.push("| Param | Type |\n|---|---|\n| id | string |\n");
+      blocks.push(`\`\`\`json\n{"id": "urn:entity:${i}"}\n\`\`\`\n`);
+      blocks.push(`Use \`param${i}\` for filtering.\n`);
+    }
+    const content = blocks.join("\n");
+
+    const result = protectCodeBlocks(content);
+    // 50 http blocks + 50 json blocks = 100 code blocks
+    expect(result.map.size).toBeGreaterThanOrEqual(100);
+    // 50 inline codes
+    expect(result.text).toContain("__INLINE_CODE_");
+    // No raw code blocks in output
+    expect(result.text).not.toMatch(/```http\n/);
+    expect(result.text).not.toMatch(/```json\n/);
+  });
+
+  it("should handle unclosed code fence gracefully", () => {
+    // protectCodeBlocks imported at top level
+
+    const content = "# Title\n\n```json\n{\"unclosed\": true}\n\nSome text after.";
+    const result = protectCodeBlocks(content);
+
+    // Unclosed fence should be emitted as-is, not swallowed
+    expect(result.text).toContain("```json");
+    expect(result.text).toContain('"unclosed"');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace regex-based `protectCodeBlocks` with a line-by-line parser
- Fixes "Maximum call stack size exceeded" on ngsild.md translation in CI (GitHub Actions)
- Root cause: `/(`{3,})[^\n]*\n[\s\S]*?\1/g` backreference + non-greedy `[\s\S]*?` caused V8 recursive backtracking

## Details
The previous regex worked locally but caused stack overflow on CI runners (smaller default stack size). The new parser:
- Tracks fence open/close state line by line
- O(n) complexity, zero recursion
- Handles unclosed fences gracefully (emits as-is)
- Correctly matches closing fences (same or more backticks)

## Test plan
- [x] All 178 existing tests pass
- [x] New test: 100 code blocks (ngsild.md pattern) — no stack overflow
- [x] New test: unclosed code fence handling
- [ ] CI passes on GitHub Actions
- [ ] geonicdb-docs translation pipeline succeeds for ngsild.md after npm publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stack overflow errors when processing documents with many code blocks
  * Enhanced code block detection for improved stability and reliability

* **Tests**
  * Added tests for code block protection with edge cases, including unclosed code fences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->