### PR TITLE
fix: CodeRabbit Actionable 4件修正（CLI バリデーション・XML エスケープ・UUID placeholder）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.11] - 2026-04-30
+
+### Fixed
+- `yuuhitsu glossary check`: --severity-filter に無効値を渡すと exit 1 + 具体的エラーメッセージを出力
+- `yuuhitsu glossary check`: --format に無効値を渡すと exit 1 + 具体的エラーメッセージを出力
+- `yuuhitsu glossary fix`: URL placeholder に UUID suffix を付加し、本文中の `__URL_N__` パターンとの衝突リスクを解消
+- `buildGlossaryPrompt`: XML 出力で `&` `<` `>` を正しくエスケープ（`&amp;` `&lt;` `&gt;`）
+- `buildGlossaryPrompt`: few-shot example を do_not_use あり項目から最大 3 件取得するよう修正（旧: slice(0,2) で 0〜1 件しか取れないケースあり）
+
+Closes https://github.com/geolonia/yuuhitsu/issues/42
+
 ## [0.1.10] - 2026-04-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.9",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/yuuhitsu",
-      "version": "0.1.9",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",
   "bin": {

--- a/src/cli/commands/glossary.ts
+++ b/src/cli/commands/glossary.ts
@@ -51,6 +51,29 @@ const checkCmd = new Command("check")
   .option("--format <format>", "Output format: text, json, sarif (default: text)", "text")
   .action(async (opts) => {
     try {
+      // Validate --severity-filter values
+      const validSeverityLevels: GlossarySeverity[] = ['block', 'warn', 'auto-fix'];
+      if (opts.severityFilter) {
+        const levels = opts.severityFilter.split(",").map((s: string) => s.trim());
+        for (const level of levels) {
+          if (!validSeverityLevels.includes(level as GlossarySeverity)) {
+            process.stderr.write(
+              `Invalid --severity-filter value '${level}'. Must be one of: block, warn, auto-fix\n`
+            );
+            process.exit(1);
+          }
+        }
+      }
+
+      // Validate --format value
+      const validFormats: GlossaryOutputFormat[] = ['text', 'json', 'sarif'];
+      if (!validFormats.includes(opts.format as GlossaryOutputFormat)) {
+        process.stderr.write(
+          `Invalid --format value '${opts.format}'. Must be one of: text, json, sarif\n`
+        );
+        process.exit(1);
+      }
+
       const severityFilter = opts.severityFilter
         ? (opts.severityFilter.split(",").map((s: string) => s.trim()) as GlossarySeverity[])
         : undefined;

--- a/src/tasks/glossary-fix.ts
+++ b/src/tasks/glossary-fix.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "fs";
+import { randomUUID } from "crypto";
 import { loadGlossary } from "./glossary.js";
 import { protectCodeBlocks, restoreCodeBlocks } from "./translate.js";
 
@@ -41,11 +42,12 @@ export function fixGlossary(
   // Protect code blocks, URLs, and URNs before replacement
   const { text: protectedContent, map: codeMap } = protectCodeBlocks(docContent);
 
-  // Also protect URLs and URNs with placeholders
+  // Also protect URLs and URNs with placeholders (UUID suffix prevents collision with document content)
   const urlMap = new Map<string, string>();
+  const urlUuid = randomUUID().replace(/-/g, "");
   let urlIndex = 0;
   const urlProtected = protectedContent.replace(/https?:\/\/\S+|urn:\S+/g, (match) => {
-    const placeholder = `__URL_${urlIndex++}__`;
+    const placeholder = `__YUUHITSU_URL_${urlUuid}_${urlIndex++}__`;
     urlMap.set(placeholder, match);
     return placeholder;
   });

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -503,7 +503,9 @@ function escapeXml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
 }
 
 export function buildGlossaryPrompt(
@@ -576,8 +578,8 @@ export function buildGlossaryPrompt(
       const forbidden = term.do_not_use?.[targetLang] ?? [];
       parts.push(
         `<example>`,
-        `  <input>...${forbidden[0]}...</input>`,
-        `  <output>...${canonical}...</output>`,
+        `  <input>...${escapeXml(forbidden[0])}...</input>`,
+        `  <output>...${escapeXml(canonical)}...</output>`,
         `</example>`,
       );
     }

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -526,12 +526,12 @@ export function buildGlossaryPrompt(
 
   const parts: string[] = [];
 
-  // Severity=block terms are re-stated at the top for emphasis
+  // Severity=block terms are re-stated at the top for emphasis (plain text, no XML escaping)
   if (blockTerms.length > 0) {
     parts.push("STRICT BRAND TERMS — these must be used exactly as specified:");
     for (const term of blockTerms) {
       const canonical = term.translations[targetLang] ?? term.canonical;
-      parts.push(`  - "${escapeXml(term.canonical)}" MUST be rendered as "${escapeXml(canonical)}" (no exceptions)`);
+      parts.push(`  - "${term.canonical}" MUST be rendered as "${canonical}" (no exceptions)`);
     }
     parts.push("");
   }
@@ -567,14 +567,20 @@ export function buildGlossaryPrompt(
     "- severity=auto-fix: preferred form, machine-replaceable",
   );
 
-  // Few-shot examples: take up to 3 terms that have do_not_use entries
+  // Few-shot examples: take up to 3 terms that have do_not_use entries and a non-empty translation
+  const renderedTermCanonical = (term: GlossaryTerm) =>
+    term.translations[targetLang]?.trim() || term.canonical;
   const exampleTerms = relevantTerms
-    .filter((t) => (t.do_not_use?.[targetLang] ?? []).length > 0)
+    .filter(
+      (t) =>
+        (t.do_not_use?.[targetLang] ?? []).length > 0 &&
+        !!(t.translations[targetLang]?.trim())
+    )
     .slice(0, 3);
   if (exampleTerms.length > 0) {
     parts.push("", "Examples:");
     for (const term of exampleTerms) {
-      const canonical = term.translations[targetLang] ?? term.canonical;
+      const canonical = renderedTermCanonical(term);
       const forbidden = term.do_not_use?.[targetLang] ?? [];
       parts.push(
         `<example>`,

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -590,9 +590,11 @@ export function buildGlossaryPrompt(
     for (const term of exampleTerms) {
       const canonical = renderedTermCanonical(term);
       const forbidden = term.do_not_use?.[targetLang] ?? [];
+      const firstForbidden = forbidden.find((f) => typeof f === "string" && f.trim().length > 0);
+      if (!firstForbidden) continue;
       parts.push(
         `<example>`,
-        `  <input>...${escapeXml(forbidden[0])}...</input>`,
+        `  <input>...${escapeXml(firstForbidden)}...</input>`,
         `  <output>...${escapeXml(canonical)}...</output>`,
         `</example>`,
       );

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -520,6 +520,12 @@ export function buildGlossaryPrompt(
     return "";
   }
 
+  // Unified helper: treat empty-string stubs (from syncGlossary) as missing
+  const renderedTermCanonical = (term: GlossaryTerm): string => {
+    const raw = term.translations[targetLang];
+    return (typeof raw === "string" && raw.trim().length > 0) ? raw.trim() : term.canonical;
+  };
+
   // canonical-first: sort by canonical name so reference order is predictable
   const blockTerms = relevantTerms.filter((t) => t.severity === 'block');
   const otherTerms = relevantTerms.filter((t) => t.severity !== 'block');
@@ -530,7 +536,7 @@ export function buildGlossaryPrompt(
   if (blockTerms.length > 0) {
     parts.push("STRICT BRAND TERMS — these must be used exactly as specified:");
     for (const term of blockTerms) {
-      const canonical = term.translations[targetLang] ?? term.canonical;
+      const canonical = renderedTermCanonical(term);
       parts.push(`  - "${term.canonical}" MUST be rendered as "${canonical}" (no exceptions)`);
     }
     parts.push("");
@@ -539,7 +545,7 @@ export function buildGlossaryPrompt(
   // XML-wrapped glossary body
   const termXml: string[] = [];
   for (const term of [...blockTerms, ...otherTerms]) {
-    const canonical = term.translations[targetLang] ?? term.canonical;
+    const canonical = renderedTermCanonical(term);
     const forbidden = term.do_not_use?.[targetLang] ?? [];
     const severity = term.severity ?? 'warn';
     const forbiddenXml = forbidden.length > 0
@@ -568,13 +574,15 @@ export function buildGlossaryPrompt(
   );
 
   // Few-shot examples: take up to 3 terms that have do_not_use entries and a non-empty translation
-  const renderedTermCanonical = (term: GlossaryTerm) =>
-    term.translations[targetLang]?.trim() || term.canonical;
   const exampleTerms = relevantTerms
     .filter(
-      (t) =>
-        (t.do_not_use?.[targetLang] ?? []).length > 0 &&
-        !!(t.translations[targetLang]?.trim())
+      (t) => {
+        const raw = t.translations[targetLang];
+        return (
+          (t.do_not_use?.[targetLang] ?? []).length > 0 &&
+          typeof raw === "string" && raw.trim().length > 0
+        );
+      }
     )
     .slice(0, 3);
   if (exampleTerms.length > 0) {

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -499,6 +499,13 @@ export function reviewGlossary(glossaryPath: string): ReviewReport {
 // buildGlossaryPrompt — helper for translate integration
 // ---------------------------------------------------------------------------
 
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 export function buildGlossaryPrompt(
   glossaryConfig: GlossaryConfig,
   targetLang: string
@@ -522,7 +529,7 @@ export function buildGlossaryPrompt(
     parts.push("STRICT BRAND TERMS — these must be used exactly as specified:");
     for (const term of blockTerms) {
       const canonical = term.translations[targetLang] ?? term.canonical;
-      parts.push(`  - "${term.canonical}" MUST be rendered as "${canonical}" (no exceptions)`);
+      parts.push(`  - "${escapeXml(term.canonical)}" MUST be rendered as "${escapeXml(canonical)}" (no exceptions)`);
     }
     parts.push("");
   }
@@ -534,11 +541,11 @@ export function buildGlossaryPrompt(
     const forbidden = term.do_not_use?.[targetLang] ?? [];
     const severity = term.severity ?? 'warn';
     const forbiddenXml = forbidden.length > 0
-      ? forbidden.map((f) => `    <do_not_use>${f}</do_not_use>`).join("\n")
+      ? forbidden.map((f) => `    <do_not_use>${escapeXml(f)}</do_not_use>`).join("\n")
       : "";
     const termEntry = [
-      `  <term canonical="${canonical}" severity="${severity}">`,
-      `    <source>${term.canonical}</source>`,
+      `  <term canonical="${escapeXml(canonical)}" severity="${severity}">`,
+      `    <source>${escapeXml(term.canonical)}</source>`,
       ...(forbiddenXml ? [forbiddenXml] : []),
       `  </term>`,
     ].join("\n");
@@ -558,21 +565,21 @@ export function buildGlossaryPrompt(
     "- severity=auto-fix: preferred form, machine-replaceable",
   );
 
-  // Few-shot examples
-  const exampleTerms = relevantTerms.slice(0, 2);
+  // Few-shot examples: take up to 3 terms that have do_not_use entries
+  const exampleTerms = relevantTerms
+    .filter((t) => (t.do_not_use?.[targetLang] ?? []).length > 0)
+    .slice(0, 3);
   if (exampleTerms.length > 0) {
     parts.push("", "Examples:");
     for (const term of exampleTerms) {
       const canonical = term.translations[targetLang] ?? term.canonical;
       const forbidden = term.do_not_use?.[targetLang] ?? [];
-      if (forbidden.length > 0) {
-        parts.push(
-          `<example>`,
-          `  <input>...${forbidden[0]}...</input>`,
-          `  <output>...${canonical}...</output>`,
-          `</example>`,
-        );
-      }
+      parts.push(
+        `<example>`,
+        `  <input>...${forbidden[0]}...</input>`,
+        `  <output>...${canonical}...</output>`,
+        `</example>`,
+      );
     }
   }
 

--- a/tests/unit/cli/glossary-command.test.ts
+++ b/tests/unit/cli/glossary-command.test.ts
@@ -103,6 +103,73 @@ describe("Glossary CLI Command", () => {
     });
   });
 
+  describe("glossary check — enum validation", () => {
+    it("should exit 1 with error message for invalid --severity-filter value", async () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja, en]\nterms: []\n");
+
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await expect(
+        checkCmd.parseAsync(
+          ["--input", docPath, "--glossary", glossaryPath, "--lang", "ja", "--severity-filter", "invalid"],
+          { from: "user" }
+        )
+      ).rejects.toThrow();
+
+      const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(stderr).toContain("Invalid --severity-filter value 'invalid'");
+      expect(stderr).toContain("block, warn, auto-fix");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it("should exit 1 with error message for invalid --format value", async () => {
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja, en]\nterms: []\n");
+
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit called");
+      });
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await expect(
+        checkCmd.parseAsync(
+          ["--input", docPath, "--glossary", glossaryPath, "--lang", "ja", "--format", "xml"],
+          { from: "user" }
+        )
+      ).rejects.toThrow();
+
+      const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(stderr).toContain("Invalid --format value 'xml'");
+      expect(stderr).toContain("text, json, sarif");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it("should accept valid comma-separated --severity-filter values", async () => {
+      vi.mocked(checkGlossary).mockReturnValue([]);
+      const docPath = join(tempDir, "doc.md");
+      writeFileSync(docPath, "# Test\n");
+      const glossaryPath = join(tempDir, "glossary.yaml");
+      writeFileSync(glossaryPath, "version: 1\nlanguages: [ja, en]\nterms: []\n");
+
+      const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;
+      await checkCmd.parseAsync(
+        ["--input", docPath, "--glossary", glossaryPath, "--lang", "ja", "--severity-filter", "block,warn"],
+        { from: "user" }
+      );
+      expect(checkGlossary).toHaveBeenCalled();
+    });
+  });
+
   describe("glossary check subcommand", () => {
     it("should require --input option", async () => {
       const checkCmd = glossaryCommand.commands.find((c) => c.name() === "check")!;

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -1345,8 +1345,7 @@ terms:
       };
       const prompt = buildGlossaryPrompt(config, "ja");
       const exampleCount = (prompt.match(/<example>/g) ?? []).length;
-      expect(exampleCount).toBeGreaterThanOrEqual(1);
-      expect(exampleCount).toBeLessThanOrEqual(3);
+      expect(exampleCount).toBe(3);
     });
 
     it("should include examples only from terms with do_not_use entries", () => {

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -1243,6 +1243,203 @@ terms:
   });
 
   // ---------------------------------------------------------------------------
+  // CodeRabbit fix: buildGlossaryPrompt — XML escaping
+  // ---------------------------------------------------------------------------
+  describe("buildGlossaryPrompt — XML escaping", () => {
+    it("should escape & in canonical term name", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["en"],
+        terms: [
+          {
+            canonical: "A & B",
+            type: "noun",
+            severity: "warn",
+            translations: { en: "A & B" },
+            do_not_use: { en: ["A and B"] },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "en");
+      expect(prompt).toContain("&amp;");
+      expect(prompt).not.toContain(' canonical="A & B"');
+    });
+
+    it("should escape < and > in do_not_use values", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["en"],
+        terms: [
+          {
+            canonical: "tag",
+            type: "noun",
+            severity: "warn",
+            translations: { en: "tag" },
+            do_not_use: { en: ["<tag>"] },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "en");
+      expect(prompt).toContain("&lt;tag&gt;");
+      expect(prompt).not.toContain("<do_not_use><tag></do_not_use>");
+    });
+
+    it("should produce valid XML structure with special characters in glossary", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["en"],
+        terms: [
+          {
+            canonical: "R&D",
+            type: "noun",
+            severity: "block",
+            translations: { en: "R&D" },
+            do_not_use: { en: ["R & D", "R<D"] },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "en");
+      expect(prompt).toContain("&amp;");
+      expect(prompt).toContain("&lt;");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CodeRabbit fix: buildGlossaryPrompt — few-shot example count
+  // ---------------------------------------------------------------------------
+  describe("buildGlossaryPrompt — few-shot examples", () => {
+    it("should include up to 3 few-shot examples", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["ja"],
+        terms: [
+          {
+            canonical: "Term1",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "ターム1" },
+            do_not_use: { ja: ["旧称1"] },
+          },
+          {
+            canonical: "Term2",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "ターム2" },
+            do_not_use: { ja: ["旧称2"] },
+          },
+          {
+            canonical: "Term3",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "ターム3" },
+            do_not_use: { ja: ["旧称3"] },
+          },
+          {
+            canonical: "Term4",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "ターム4" },
+            do_not_use: { ja: ["旧称4"] },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "ja");
+      const exampleCount = (prompt.match(/<example>/g) ?? []).length;
+      expect(exampleCount).toBeGreaterThanOrEqual(1);
+      expect(exampleCount).toBeLessThanOrEqual(3);
+    });
+
+    it("should include examples only from terms with do_not_use entries", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["ja"],
+        terms: [
+          {
+            canonical: "NoForbidden",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "禁止語なし" },
+          },
+          {
+            canonical: "HasForbidden",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "禁止語あり" },
+            do_not_use: { ja: ["旧称"] },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "ja");
+      const exampleCount = (prompt.match(/<example>/g) ?? []).length;
+      expect(exampleCount).toBe(1);
+      expect(prompt).toContain("旧称");
+    });
+
+    it("should produce no examples when no terms have do_not_use", () => {
+      const config: GlossaryConfig = {
+        version: 1,
+        languages: ["ja"],
+        terms: [
+          {
+            canonical: "Term",
+            type: "noun",
+            severity: "warn",
+            translations: { ja: "用語" },
+          },
+        ],
+      };
+      const prompt = buildGlossaryPrompt(config, "ja");
+      expect(prompt).not.toContain("<example>");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // CodeRabbit fix: fixGlossary — UUID placeholder collision prevention
+  // ---------------------------------------------------------------------------
+  describe("fixGlossary — UUID placeholder collision", () => {
+    let glossaryPath: string;
+
+    beforeEach(() => {
+      glossaryPath = join(tempDir, "glossary-uuid.yaml");
+      writeFileSync(
+        glossaryPath,
+        `version: 1
+languages: [ja]
+terms:
+  - canonical: "サブスクリプション"
+    type: noun
+    severity: auto-fix
+    translations:
+      ja: "サブスクリプション"
+    do_not_use:
+      ja: ["サブスク"]
+`
+      );
+    });
+
+    it("should correctly handle document containing legacy placeholder pattern __URL_0__", () => {
+      const docPath = join(tempDir, "doc-placeholder.md");
+      const original = "このドキュメントには __URL_0__ というテキストとサブスクへの言及があります。\n";
+      writeFileSync(docPath, original);
+      const result = fixGlossary(docPath, glossaryPath, "ja");
+      const content = readFileSync(docPath, "utf-8");
+      expect(content).toContain("__URL_0__");
+      expect(content).toContain("サブスクリプション");
+      expect(result.changed).toBe(true);
+    });
+
+    it("should not corrupt document when URL contains forbidden word", () => {
+      const docPath = join(tempDir, "doc-url.md");
+      writeFileSync(docPath, "参照: https://example.com/サブスク/overview\nサブスクを使ってください。\n");
+      const result = fixGlossary(docPath, glossaryPath, "ja");
+      const content = readFileSync(docPath, "utf-8");
+      expect(content).toContain("https://example.com/サブスク/overview");
+      expect(content).toContain("サブスクリプションを使ってください");
+      expect(result.replacements).toBe(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Phase 3: SARIF formatter
   // ---------------------------------------------------------------------------
   describe("formatSarif", () => {


### PR DESCRIPTION
## 概要

cmd_317 PR#41 で未対応のまま残った CodeRabbit Actionable 指摘 4件を修正し、yuuhitsu 0.1.11 としてリリースする。

## 修正内容

- `src/cli/commands/glossary.ts`: `--severity-filter` / `--format` の enum バリデーション追加（不正値は exit 1 + 具体的エラーメッセージ）
- `src/tasks/glossary-fix.ts`: URL placeholder を UUID v4 ベース（`__YUUHITSU_URL_<uuid>_<idx>__`）に変更し、本文中の `__URL_0__` パターンとの衝突リスクを解消
- `src/tasks/glossary.ts`: XML エスケープ関数 `escapeXml()` を新設し、`buildGlossaryPrompt` の全 XML 出力に適用（`&` `<` `>` → `&amp;` `&lt;` `&gt;`）
- `src/tasks/glossary.ts`: few-shot example 抽出を `do_not_use` あり項目から最大 3 件に修正（旧: `slice(0,2)` で 0〜1 件しか取れないケースあり）

## テスト

- 既存テスト全 PASS（regression なし）
- 新規テスト 11件追加（SKIP=0）
  - CLI: `--severity-filter` / `--format` 不正値で exit 1（3件）
  - glossary: XML 特殊文字エスケープ（3件）
  - glossary: few-shot 1〜3 件取得（3件）
  - glossary-fix: UUID placeholder 衝突なし（2件）

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate CLI options: `glossary check` now rejects invalid severity/format values with clear error messages and exit code 1.
  * Avoid URL placeholder collisions in `glossary fix` by using UUID-suffixed placeholders.
  * Escape XML special characters in generated glossary prompts.
  * Improve few-shot example selection to include up to 3 appropriate examples.

* **Documentation**
  * Add CHANGELOG entry for version 0.1.11.

* **Tests**
  * Add unit tests covering CLI validation, prompt escaping, example selection, and fix safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->