### PR TITLE
feat(prompt): SF1 code fence lang 必須化 + glossary warn 強化 (0.1.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `DEFAULT_TEMPLATE`: Added bash counter-example showing correct vs incorrect code fence usage
 - `buildGlossaryPrompt`: Added `do_not_use` entries as forbidden regardless of severity (block/warn/auto-fix)
 - `buildGlossaryPrompt`: Strengthened `severity=warn` wording to "actively avoid all do_not_use forms; treat warn terms as near-mandatory"
+- Note: These prompt-strengthening rules are not applied when using `--template-content` with a custom prompt.
 
 ### Tests
 - NEW-1: fence lang 必須文言が DEFAULT_TEMPLATE に存在すること

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.13] - 2026-05-02
+
+### Changed
+- `DEFAULT_TEMPLATE`: Added mandatory code fence language identifier rule — every opening ` ``` ` must be followed by a language identifier; use ` ```text ` when unknown
+- `DEFAULT_TEMPLATE`: Added bash counter-example showing correct vs incorrect code fence usage
+- `buildGlossaryPrompt`: Added `do_not_use` entries as forbidden regardless of severity (block/warn/auto-fix)
+- `buildGlossaryPrompt`: Strengthened `severity=warn` wording to "actively avoid all do_not_use forms; treat warn terms as near-mandatory"
+
+### Tests
+- NEW-1: fence lang 必須文言が DEFAULT_TEMPLATE に存在すること
+- NEW-2: warn 強化文言が buildGlossaryPrompt に存在すること
+- NEW-3: glossary 未設定時に warn 強化文言が出現しないこと
+
+Closes https://github.com/geolonia/yuuhitsu/issues/47
+
 ## [0.1.12] - 2026-05-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geolonia/yuuhitsu",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",
   "bin": {

--- a/src/tasks/glossary.ts
+++ b/src/tasks/glossary.ts
@@ -591,8 +591,9 @@ export function buildGlossaryPrompt(
     "Glossary usage rules:",
     "- Use the canonical translation for each term",
     "- Never use any do_not_use alternatives",
+    "- Treat the glossary's do_not_use entries as forbidden, regardless of severity (block / warn / auto-fix)",
     "- severity=block: strict brand requirement, zero exceptions",
-    "- severity=warn: strong preference, use canonical unless context requires otherwise",
+    "- severity=warn: actively avoid all do_not_use forms; use the canonical translation except when quoting source material verbatim. Treat warn terms as near-mandatory.",
     "- severity=auto-fix: preferred form, machine-replaceable",
   );
 

--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -149,6 +149,8 @@ Rules:
 - Do not translate frontmatter keys (only translate values where appropriate)
 - Maintain the same document structure
 - Produce natural, fluent text in the target language
+- Every opening \`\`\` you write MUST be followed by a language identifier on the same line (e.g., \`\`\`json, \`\`\`bash, \`\`\`typescript)
+- If the language is unknown, use \`\`\`text — never emit a bare opening \`\`\`
 
 CRITICAL - Link and URL preservation:
 - NEVER modify any URLs or link paths. Keep all href/src values exactly as-is.
@@ -162,7 +164,11 @@ Additional rules for Japanese translation:
 - Use full-width punctuation: 。、？！ (not .,?!)
 - Add half-width spaces around English words and numbers (e.g., "Vela とは", "NGSIv2 は", "3 つの")
 - Use natural Japanese terms for technical words where appropriate (e.g., "registration" → "登録", "subscription" → "サブスクリプション")
-- Keep product names, proper nouns, and abbreviations unchanged (e.g., Vela, FIWARE, NGSIv2, NGSI-LD, MCP)`;
+- Keep product names, proper nouns, and abbreviations unchanged (e.g., Vela, FIWARE, NGSIv2, NGSI-LD, MCP)
+
+Example — code fence with language identifier:
+  Bad:  \`\`\` echo hello \`\`\`
+  Good: \`\`\`bash echo hello \`\`\``;
 
 function buildPrompt(
   content: string,

--- a/tests/unit/tasks/translate-glossary.test.ts
+++ b/tests/unit/tasks/translate-glossary.test.ts
@@ -135,4 +135,58 @@ describe("Translate Task - Glossary Integration", () => {
     // Canonical translation for ja should appear
     expect(systemMsg.content).toContain("Webhook");
   });
+
+  // NEW-1: fence lang 必須文言が DEFAULT_TEMPLATE に存在すること
+  it("NEW-1: should include code fence lang requirement rule in default template", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Test\n");
+
+    const mockProvider = createMockProvider("# テスト\n");
+    await translateFile({ provider: mockProvider, inputPath, outputPath, targetLang: "ja" });
+
+    const systemMsg = mockProvider.chat.mock.calls[0][0].messages.find(
+      (m: any) => m.role === "system",
+    );
+    expect(systemMsg.content).toContain("MUST be followed by a language identifier");
+    expect(systemMsg.content).toContain("never emit a bare opening");
+  });
+
+  // NEW-2: warn 強化文言が buildGlossaryPrompt に存在すること
+  it("NEW-2: should include strengthened warn rule when glossary is provided", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Test\n");
+
+    const mockProvider = createMockProvider("# テスト\n");
+    await translateFile({
+      provider: mockProvider,
+      inputPath,
+      outputPath,
+      targetLang: "ja",
+      glossaryConfig: sampleGlossary,
+    });
+
+    const systemMsg = mockProvider.chat.mock.calls[0][0].messages.find(
+      (m: any) => m.role === "system",
+    );
+    expect(systemMsg.content).toContain("near-mandatory");
+    expect(systemMsg.content).toContain("regardless of severity");
+  });
+
+  // NEW-3: glossary 未設定時に warn 強化文言が出現しないこと
+  it("NEW-3: should not include warn strengthening text when glossaryConfig is undefined", async () => {
+    const inputPath = join(tempDir, "input.md");
+    const outputPath = join(tempDir, "output.ja.md");
+    writeFileSync(inputPath, "# Test\n");
+
+    const mockProvider = createMockProvider("# テスト\n");
+    await translateFile({ provider: mockProvider, inputPath, outputPath, targetLang: "ja" });
+
+    const systemMsg = mockProvider.chat.mock.calls[0][0].messages.find(
+      (m: any) => m.role === "system",
+    );
+    expect(systemMsg.content).not.toContain("near-mandatory");
+    expect(systemMsg.content).not.toContain("regardless of severity");
+  });
 });


### PR DESCRIPTION
Closes https://github.com/geolonia/yuuhitsu/issues/47

## 変更内容
- 改訂 1: DEFAULT_TEMPLATE Rules に code fence lang 必須ルール追加（`every opening ``` MUST be followed by a language identifier`）
- 改訂 2: buildGlossaryPrompt に do_not_use 全 tier 禁止強化追加（Q3=B: DEFAULT_TEMPLATE には追加せず）
- 改訂 3: severity=warn 文言を near-mandatory に強化
- 改訂 4: DEFAULT_TEMPLATE 末尾に bash counter-example 追加（Q4=A）
- 新規テスト NEW-1〜3 追加（全 224 件 PASS・SKIP=0）
- package.json 0.1.12 → 0.1.13

## リリースノート（Q5=A 後方互換）
`--template-content` でカスタム prompt を使用している場合、SF1 強化（code fence lang 必須化・glossary warn 強化）は適用されません。
これらの強化を受けるには default template を使用してください。

## npm publish
**殿手動実施**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enforce language identifiers on all fenced code blocks; default to `text` when unknown.
  * Treat `do_not_use` glossary entries as forbidden regardless of severity.
  * Strengthen guidance for warn-level glossary terms to actively avoid them except when verbatim quoting.

* **Documentation**
  * Changelog updated with the above rules and examples.

* **Tests**
  * Added tests asserting presence/absence of the new prompt/glossary rules.

* **Chores**
  * Package version bumped to 0.1.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->