### PR TITLE
feat(sentinel): yuuhitsu 0.1.16 — <!--BB--> sentinel + 3-pass restore + LLM integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,8 +15,9 @@ permissions:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
     timeout-minutes: 20
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -24,8 +25,7 @@ jobs:
           node-version: "20"
       - run: npm ci
       - name: Run integration tests
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
         run: npm run test:integration
       - name: Upload test results
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,36 @@
+name: Integration Tests (real LLM)
+
+on:
+  pull_request:
+    paths:
+      - "src/tasks/translate.ts"
+      - "tests/integration/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Run integration tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: npm run test:integration
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: integration-test-results
+          path: test-results/integration/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .env
 *.log
+.code-review-done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [0.1.16] - 2026-05-05
+
+### Changed
+- `BLOCK_BOUNDARY_SENTINEL`: `"%%BB%%"` → `"<!--BB-->"` (HTML comment form, LLM deformation-resistant)
+  - HTML comments have strong LLM training prior as "structural elements to preserve verbatim"
+  - Eliminates the LaTeX/Liquid template `%%` reflex that caused `%%BB__` deformation in 0.1.15
+- `restoreBlockBoundaries`: 3-pass strategy for robust variant recovery
+  - Pass 1: normalize LLM-deformed variants via fallback regex (`<!-- BB -->`, `<!--BB__-->`, `<!--BBx-->`, `<!--BB-x-->`, etc.)
+  - Pass 2: split + restore newlines (existing logic, unchanged)
+  - Pass 3: post-restore `console.warn` for residual sentinel-like patterns (silent failure prevention)
+- `buildPrompt`: sentinel preservation instruction updated to `<!--BB-->` with counter-example section
+  - 5 Bad examples (suffix insertion / internal whitespace / case change / deletion / hyphen suffix)
+  - +135 tokens vs 0.1.15 +120 tokens (acceptable delta)
+
+### Added
+- `tests/integration/translate-block-boundaries.real-llm.test.ts`: real LLM integration test (Claude Sonnet 4.6 × 5 fixtures)
+  - Fixture 1: PR#155 list-list newline preservation
+  - Fixture 2: PR#161 macOS/Windows list + 4-backtick fence
+  - Fixture 3: PR#166 3-item JSON list
+  - Fixture 4: PR#161 heading + inline-code + body
+  - Fixture 5: PR#155 hr + heading
+  - Graceful skip when `ANTHROPIC_API_KEY` is not set
+- `.github/workflows/integration-tests.yml`: CI workflow for real LLM tests
+  - Triggers: pull_request (translate.ts + integration tests), workflow_dispatch, weekly schedule (Monday 09:00 UTC)
+  - Runs only when `ANTHROPIC_API_KEY` secret is available
+
+### Tests (8 new unit tests)
+- `translate-block-boundaries.test.ts`: 8 variant detection tests
+  - `<!-- BB -->`, `<!--BB__-->`, `<!--BBx-->`, `<!--BB-x-->`, `<!--  BB  -->` normalized via fallback
+  - Round-trip with `<!-- BB -->` and `<!--BB__-->` variants returns original
+  - Exact sentinel unaffected by fallback pass (no double-processing)
+
+### Migration (0.1.15 → 0.1.16)
+- Sentinel format changed: existing translated docs with `%%BB__` residuals will be re-translated correctly on next sync run
+- `fix-doc-quality.ts` 7 functions maintained (Phase 3 deletion frozen per cmd_389 Q6)
+
+Closes https://github.com/geolonia/yuuhitsu/issues/56
+
 ## [0.1.15] - 2026-05-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",
   "bin": {
@@ -12,6 +12,7 @@
     "dev": "tsx src/cli/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run tests/integration/translate-block-boundaries.real-llm.test.ts",
     "lint": "tsc --noEmit"
   },
   "keywords": [

--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -138,10 +138,10 @@ const SENTINEL_RESIDUAL_CHECK = /<!--[\s\S]*?BB[\s\S]*?-->/g;
  * the function treats those placeholders as structural to protect fence-adjacent newlines.
  */
 export function protectBlockBoundaries(content: string): string {
-  // Escape any pre-existing <!--BB--> so they are not confused with control sentinels
-  const escaped = content.includes(BLOCK_BOUNDARY_SENTINEL)
-    ? content.split(BLOCK_BOUNDARY_SENTINEL).join(ESCAPED_SENTINEL)
-    : content;
+  // Escape all sentinel-like patterns (exact + variants) to prevent control-marker confusion.
+  // SENTINEL_FALLBACK covers <!--BB-->, <!-- BB -->, <!--BBx-->, <!--BB-x-->, etc.
+  // On restore, these all round-trip back to <!--BB--> (minor cosmetic vs. content deletion).
+  const escaped = content.replace(SENTINEL_FALLBACK, ESCAPED_SENTINEL);
 
   const lines = escaped.split("\n");
   const result: string[] = [];

--- a/src/tasks/translate.ts
+++ b/src/tasks/translate.ts
@@ -121,10 +121,14 @@ export function restoreCodeBlocks(content: string, map: Map<string, string>): st
   return result;
 }
 
-export const BLOCK_BOUNDARY_SENTINEL = "%%BB%%";
-// Temporary escape for pre-existing %%BB%% literals in user content.
+export const BLOCK_BOUNDARY_SENTINEL = "<!--BB-->";
+// Temporary escape for pre-existing <!--BB--> literals in user content.
 // Uses a character sequence unlikely to appear in markdown documents.
 const ESCAPED_SENTINEL = "\x01BB\x01";
+// Fallback regex: catches LLM-deformed variants (e.g. <!-- BB -->, <!--BB__-->, <!--BBx-->)
+const SENTINEL_FALLBACK = /<!--\s*BB[a-zA-Z0-9_-]*\s*-->/g;
+// Broad check: detects severely-deformed residuals not caught by SENTINEL_FALLBACK
+const SENTINEL_RESIDUAL_CHECK = /<!--[\s\S]*?BB[\s\S]*?-->/g;
 
 /**
  * Insert block boundary sentinels before structural Markdown elements
@@ -134,7 +138,7 @@ const ESCAPED_SENTINEL = "\x01BB\x01";
  * the function treats those placeholders as structural to protect fence-adjacent newlines.
  */
 export function protectBlockBoundaries(content: string): string {
-  // Escape any pre-existing %%BB%% so they are not confused with control sentinels
+  // Escape any pre-existing <!--BB--> so they are not confused with control sentinels
   const escaped = content.includes(BLOCK_BOUNDARY_SENTINEL)
     ? content.split(BLOCK_BOUNDARY_SENTINEL).join(ESCAPED_SENTINEL)
     : content;
@@ -165,17 +169,24 @@ export function protectBlockBoundaries(content: string): string {
 
 /**
  * Remove block boundary sentinels and restore newlines lost during LLM translation.
- * Handles both clean (sentinel on own line) and collapsed (sentinel inline) cases.
+ * Uses a 3-pass strategy:
+ *   Pass 1: normalize LLM-deformed variants (e.g. <!-- BB -->) to exact sentinel form
+ *   Pass 2: split + restore newlines (handles both clean and collapsed sentinel cases)
+ *   Pass 3: post-restore warning for residual sentinel-like patterns (silent failure prevention)
  */
 export function restoreBlockBoundaries(content: string): string {
-  if (!content.includes(BLOCK_BOUNDARY_SENTINEL)) {
+  // Pass 1: normalize variant sentinels introduced by LLM deformation (cmd_389 Root Cause A/B)
+  const normalized = content.replace(SENTINEL_FALLBACK, BLOCK_BOUNDARY_SENTINEL);
+
+  // Pass 2: split + restore newlines
+  if (!normalized.includes(BLOCK_BOUNDARY_SENTINEL)) {
     // Still unescape any escaped sentinels from original content
-    return content.includes(ESCAPED_SENTINEL)
-      ? content.split(ESCAPED_SENTINEL).join(BLOCK_BOUNDARY_SENTINEL)
-      : content;
+    return normalized.includes(ESCAPED_SENTINEL)
+      ? normalized.split(ESCAPED_SENTINEL).join(BLOCK_BOUNDARY_SENTINEL)
+      : normalized;
   }
 
-  const parts = content.split(BLOCK_BOUNDARY_SENTINEL);
+  const parts = normalized.split(BLOCK_BOUNDARY_SENTINEL);
   let restored = parts[0];
   for (let i = 1; i < parts.length; i++) {
     // Strip a leading newline from next part (present when LLM preserved sentinel on its own line)
@@ -189,7 +200,17 @@ export function restoreBlockBoundaries(content: string): string {
     }
   }
 
-  // Unescape any pre-existing %%BB%% that were escaped before protection
+  // Pass 3: post-restore warning for patterns not caught by SENTINEL_FALLBACK
+  // Check before unescaping to avoid false positives from user-content <!--BB-->
+  const residuals = restored.match(SENTINEL_RESIDUAL_CHECK);
+  if (residuals && residuals.length > 0) {
+    console.warn(
+      `[yuuhitsu] restoreBlockBoundaries: ${residuals.length} residual sentinel-like pattern(s) detected after restore:`,
+      residuals.slice(0, 5)
+    );
+  }
+
+  // Unescape any pre-existing <!--BB--> that were escaped before protection
   if (restored.includes(ESCAPED_SENTINEL)) {
     restored = restored.split(ESCAPED_SENTINEL).join(BLOCK_BOUNDARY_SENTINEL);
   }
@@ -268,29 +289,39 @@ function buildPrompt(
 
   if (hasSentinels) {
     systemPrompt +=
-      "\n\n## Block boundary markers (P-A4)\n" +
-      "Lines containing the marker `%%BB%%` are **block boundary markers** inserted by the\n" +
-      "translation pipeline to preserve newlines around structural elements.\n\n" +
-      "Rules for `%%BB%%` markers:\n" +
-      "- Output every `%%BB%%` marker **verbatim and unchanged** in your translation.\n" +
-      "- Each marker must remain on its own line, in the same position relative to surrounding content.\n" +
-      "- Do not translate, remove, paraphrase, or modify these markers.\n" +
-      "- Do not add new `%%BB%%` markers; only preserve existing ones.\n\n" +
-      "Example:\n" +
+      "\n\n## Block boundary markers (P-A4 v2)\n\n" +
+      "Lines containing the marker `<!--BB-->` are **block boundary markers** inserted\n" +
+      "by the translation pipeline to preserve newlines around structural elements.\n\n" +
+      "Rules for `<!--BB-->` markers (HTML comment form):\n" +
+      "- Output every `<!--BB-->` marker **verbatim and unchanged** in your translation.\n" +
+      "- Each marker must remain on its own line, in the same position relative to\n" +
+      "  surrounding content.\n" +
+      "- Do not translate, remove, paraphrase, modify, normalize whitespace inside, or\n" +
+      "  rename these markers.\n" +
+      "- Do not add new `<!--BB-->` markers; only preserve existing ones.\n\n" +
+      "Good example (correct preservation):\n" +
       "  Input:\n" +
-      "    %%BB%%\n" +
+      "    <!--BB-->\n" +
       "    - List item one\n" +
-      "    %%BB%%\n" +
+      "    <!--BB-->\n" +
       "    - List item two\n" +
-      "    %%BB%%\n" +
+      "    <!--BB-->\n" +
       "    ## Section heading\n" +
       "  Output:\n" +
-      "    %%BB%%\n" +
+      "    <!--BB-->\n" +
       "    - リスト項目その一\n" +
-      "    %%BB%%\n" +
+      "    <!--BB-->\n" +
       "    - リスト項目その二\n" +
-      "    %%BB%%\n" +
-      "    ## セクション見出し";
+      "    <!--BB-->\n" +
+      "    ## セクション見出し\n\n" +
+      "Bad examples (DO NOT do these):\n" +
+      "  - <!--BB-->  ❌ → <!--BB__-->     (added suffix — FORBIDDEN)\n" +
+      "  - <!--BB-->  ❌ → <!-- BB -->     (added internal whitespace — FORBIDDEN)\n" +
+      "  - <!--BB-->  ❌ → <!--bb-->       (case change — FORBIDDEN)\n" +
+      "  - <!--BB-->  ❌ → (omitted)       (deleted — FORBIDDEN)\n" +
+      "  - <!--BB-->  ❌ → <!--BB-x-->     (added suffix — FORBIDDEN)\n\n" +
+      "Preserve the marker exactly: 9 characters, opening `<!--`, content `BB`,\n" +
+      "closing `-->`, no whitespace, no case changes, no suffixes.";
   }
 
   if (hasPlaceholders) {

--- a/tests/integration/fixtures/p-a4-1.input.md
+++ b/tests/integration/fixtures/p-a4-1.input.md
@@ -1,0 +1,4 @@
+# Test
+
+- Item A: `value 1`
+- Item B: same ID conflict returns `409`

--- a/tests/integration/fixtures/p-a4-2.input.md
+++ b/tests/integration/fixtures/p-a4-2.input.md
@@ -1,0 +1,12 @@
+# Configuration
+
+Configuration paths:
+
+- **macOS**: `~/Library/Application Support`
+- **Windows**: `%APPDATA%`
+
+````json
+{
+  "key": "value"
+}
+````

--- a/tests/integration/fixtures/p-a4-3.input.md
+++ b/tests/integration/fixtures/p-a4-3.input.md
@@ -1,0 +1,7 @@
+# Examples
+
+Examples:
+
+- `{"type": "Property", "value": 25.5}`
+- `{"type": "Relationship", "object": "..."}`
+- `{"type": "GeoProperty", "value": {}}`

--- a/tests/integration/fixtures/p-a4-4.input.md
+++ b/tests/integration/fixtures/p-a4-4.input.md
@@ -1,0 +1,5 @@
+# Models
+
+## MCP Tool: `data_models`
+
+Use this tool to query Smart Data Models catalog.

--- a/tests/integration/fixtures/p-a4-5.input.md
+++ b/tests/integration/fixtures/p-a4-5.input.md
@@ -1,0 +1,9 @@
+# Protocol
+
+Previous content paragraph.
+
+---
+
+## Protocol Separation
+
+Content of new section.

--- a/tests/integration/translate-block-boundaries.real-llm.test.ts
+++ b/tests/integration/translate-block-boundaries.real-llm.test.ts
@@ -43,21 +43,21 @@ describeTest(
       return { input, output };
     }
 
-    function assertStructuralIntegrity(output: string, context: string): void {
-      // No sentinel or variant patterns in restored output
+    function assertStructuralIntegrity(input: string, output: string, context: string): void {
+      // No sentinel or variant patterns (including lowercase) in restored output
       expect(output, `${context}: should not contain <!--BB--> sentinel after restore`).not.toMatch(
-        /<!--BB-->/
+        /<!--BB-->/i
       );
       expect(output, `${context}: should not contain sentinel variants after restore`).not.toMatch(
-        /<!--\s*BB[a-zA-Z0-9_-]*\s*-->/
+        /<!--\s*BB[a-zA-Z0-9_-]*\s*-->/i
       );
 
-      // Translation completed — output should be non-empty with reasonable length
+      // Translation completed — output should be non-empty and at least 30% of input length
       expect(output.trim().length, `${context}: output should be non-empty`).toBeGreaterThan(0);
       expect(
         output.length,
         `${context}: output should be at least 30% of input length`
-      ).toBeGreaterThan(0);
+      ).toBeGreaterThanOrEqual(Math.ceil(input.length * 0.3));
     }
 
     it(
@@ -65,7 +65,7 @@ describeTest(
       async () => {
         const { input, output } = await runTranslation("p-a4-1");
 
-        assertStructuralIntegrity(output, "fixture 1");
+        assertStructuralIntegrity(input, output, "fixture 1");
 
         // List items should be on separate lines
         const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
@@ -80,9 +80,9 @@ describeTest(
     it(
       "fixture 2 (PR#161): macOS/Windows list + 4-backtick fence boundary preserved",
       async () => {
-        const { output } = await runTranslation("p-a4-2");
+        const { input, output } = await runTranslation("p-a4-2");
 
-        assertStructuralIntegrity(output, "fixture 2");
+        assertStructuralIntegrity(input, output, "fixture 2");
 
         // List items on separate lines
         const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
@@ -97,9 +97,9 @@ describeTest(
     it(
       "fixture 3 (PR#166): 3-item JSON list newlines preserved",
       async () => {
-        const { output } = await runTranslation("p-a4-3");
+        const { input, output } = await runTranslation("p-a4-3");
 
-        assertStructuralIntegrity(output, "fixture 3");
+        assertStructuralIntegrity(input, output, "fixture 3");
 
         // 3 list items on separate lines
         const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
@@ -111,9 +111,9 @@ describeTest(
     it(
       "fixture 4 (PR#161): heading + inline-code + body structure preserved",
       async () => {
-        const { output } = await runTranslation("p-a4-4");
+        const { input, output } = await runTranslation("p-a4-4");
 
-        assertStructuralIntegrity(output, "fixture 4");
+        assertStructuralIntegrity(input, output, "fixture 4");
 
         // At least one heading on its own line
         const headingLines = output.split("\n").filter((l) => /^ {0,3}#{1,6}\s/.test(l));
@@ -125,9 +125,9 @@ describeTest(
     it(
       "fixture 5 (PR#155): hr + heading boundary preserved",
       async () => {
-        const { output } = await runTranslation("p-a4-5");
+        const { input, output } = await runTranslation("p-a4-5");
 
-        assertStructuralIntegrity(output, "fixture 5");
+        assertStructuralIntegrity(input, output, "fixture 5");
 
         // Horizontal rule on its own line
         const hrLines = output.split("\n").filter((l) => /^ {0,3}(-{3,}|\*{3,}|_{3,})\s*$/.test(l));

--- a/tests/integration/translate-block-boundaries.real-llm.test.ts
+++ b/tests/integration/translate-block-boundaries.real-llm.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { tmpdir } from "os";
+import { ClaudeProvider } from "../../src/provider/claude.js";
+import { translateFile } from "../../src/tasks/translate.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "fixtures");
+
+const API_KEY = process.env.ANTHROPIC_API_KEY;
+
+// Graceful skip when no API key is available (e.g. local dev without credentials)
+const describeTest = API_KEY ? describe : describe.skip;
+
+describeTest(
+  "P-A4 <!--BB--> sentinel: real LLM integration (Claude Sonnet 4.6)",
+  () => {
+    let tempDir: string;
+    let provider: ClaudeProvider;
+
+    beforeAll(() => {
+      tempDir = join(tmpdir(), `yuuhitsu-sentinel-integration-${Date.now()}`);
+      mkdirSync(tempDir, { recursive: true });
+      provider = new ClaudeProvider("claude-sonnet-4-6");
+    });
+
+    afterAll(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    async function runTranslation(fixtureName: string): Promise<{
+      input: string;
+      output: string;
+    }> {
+      const inputPath = join(FIXTURES_DIR, `${fixtureName}.input.md`);
+      const outputPath = join(tempDir, `${fixtureName}.ja.md`);
+      const input = readFileSync(inputPath, "utf-8");
+
+      await translateFile({ provider, inputPath, outputPath, targetLang: "ja" });
+      const output = readFileSync(outputPath, "utf-8");
+      return { input, output };
+    }
+
+    function assertStructuralIntegrity(output: string, context: string): void {
+      // No sentinel or variant patterns in restored output
+      expect(output, `${context}: should not contain <!--BB--> sentinel after restore`).not.toMatch(
+        /<!--BB-->/
+      );
+      expect(output, `${context}: should not contain sentinel variants after restore`).not.toMatch(
+        /<!--\s*BB[a-zA-Z0-9_-]*\s*-->/
+      );
+
+      // Translation completed — output should be non-empty with reasonable length
+      expect(output.trim().length, `${context}: output should be non-empty`).toBeGreaterThan(0);
+      expect(
+        output.length,
+        `${context}: output should be at least 30% of input length`
+      ).toBeGreaterThan(0);
+    }
+
+    it(
+      "fixture 1 (PR#155): list-list newlines preserved after LLM round-trip",
+      async () => {
+        const { input, output } = await runTranslation("p-a4-1");
+
+        assertStructuralIntegrity(output, "fixture 1");
+
+        // List items should be on separate lines
+        const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
+        expect(
+          listLines.length,
+          "fixture 1: at least 2 list items should be on separate lines"
+        ).toBeGreaterThanOrEqual(2);
+      },
+      60000
+    );
+
+    it(
+      "fixture 2 (PR#161): macOS/Windows list + 4-backtick fence boundary preserved",
+      async () => {
+        const { output } = await runTranslation("p-a4-2");
+
+        assertStructuralIntegrity(output, "fixture 2");
+
+        // List items on separate lines
+        const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
+        expect(listLines.length, "fixture 2: list items on separate lines").toBeGreaterThanOrEqual(2);
+
+        // Code fence preserved
+        expect(output, "fixture 2: code fence should be preserved").toMatch(/```/);
+      },
+      60000
+    );
+
+    it(
+      "fixture 3 (PR#166): 3-item JSON list newlines preserved",
+      async () => {
+        const { output } = await runTranslation("p-a4-3");
+
+        assertStructuralIntegrity(output, "fixture 3");
+
+        // 3 list items on separate lines
+        const listLines = output.split("\n").filter((l) => /^\s*[-*+]\s/.test(l));
+        expect(listLines.length, "fixture 3: 3 list items on separate lines").toBeGreaterThanOrEqual(3);
+      },
+      60000
+    );
+
+    it(
+      "fixture 4 (PR#161): heading + inline-code + body structure preserved",
+      async () => {
+        const { output } = await runTranslation("p-a4-4");
+
+        assertStructuralIntegrity(output, "fixture 4");
+
+        // At least one heading on its own line
+        const headingLines = output.split("\n").filter((l) => /^ {0,3}#{1,6}\s/.test(l));
+        expect(headingLines.length, "fixture 4: headings on separate lines").toBeGreaterThanOrEqual(1);
+      },
+      60000
+    );
+
+    it(
+      "fixture 5 (PR#155): hr + heading boundary preserved",
+      async () => {
+        const { output } = await runTranslation("p-a4-5");
+
+        assertStructuralIntegrity(output, "fixture 5");
+
+        // Horizontal rule on its own line
+        const hrLines = output.split("\n").filter((l) => /^ {0,3}(-{3,}|\*{3,}|_{3,})\s*$/.test(l));
+        expect(hrLines.length, "fixture 5: horizontal rule on its own line").toBeGreaterThanOrEqual(1);
+
+        // Heading after hr
+        const headingLines = output.split("\n").filter((l) => /^ {0,3}#{1,6}\s/.test(l));
+        expect(headingLines.length, "fixture 5: heading on its own line").toBeGreaterThanOrEqual(1);
+      },
+      60000
+    );
+  }
+);

--- a/tests/unit/tasks/translate-block-boundaries.test.ts
+++ b/tests/unit/tasks/translate-block-boundaries.test.ts
@@ -74,12 +74,12 @@ describe("protectBlockBoundaries", () => {
     expect(result).toBe(`${BB}\n- parent\n${BB}\n  - child`);
   });
 
-  it("escapes pre-existing %%BB%% in user content before inserting sentinels", () => {
+  it("escapes pre-existing <!--BB--> in user content before inserting sentinels", () => {
     const input = `Some text with ${BB} literal\n- list item`;
     const result = protectBlockBoundaries(input);
-    // Pre-existing %%BB%% must not be treated as a sentinel
+    // Pre-existing <!--BB--> must not be treated as a sentinel
     expect(result.split(BB).length).toBe(2); // only one sentinel (before list item)
-    // Original %%BB%% is escaped and restorable
+    // Original <!--BB--> is escaped and restorable
     const roundTrip = restoreBlockBoundaries(result);
     expect(roundTrip).toBe(input);
   });
@@ -151,6 +151,50 @@ describe("restoreBlockBoundaries", () => {
     const input = `item A${BB}${BB}item B`;
     const restored = restoreBlockBoundaries(input);
     expect(restored).toBe("item A\nitem B");
+  });
+});
+
+describe("restoreBlockBoundaries variant detection (3-pass fallback regex)", () => {
+  it("normalizes <!-- BB --> (internal whitespace variant) via fallback", () => {
+    const input = "text<!-- BB -->sentence";
+    expect(restoreBlockBoundaries(input)).toBe("text\nsentence");
+  });
+
+  it("normalizes <!--BB__--> (underscore suffix variant) via fallback", () => {
+    expect(restoreBlockBoundaries("text<!--BB__-->sentence")).toBe("text\nsentence");
+  });
+
+  it("normalizes <!--BBx--> (letter suffix variant) via fallback", () => {
+    expect(restoreBlockBoundaries("text<!--BBx-->sentence")).toBe("text\nsentence");
+  });
+
+  it("normalizes <!--BB-x--> (hyphen suffix variant) via fallback", () => {
+    expect(restoreBlockBoundaries("text<!--BB-x-->sentence")).toBe("text\nsentence");
+  });
+
+  it("normalizes <!--  BB  --> (multiple spaces variant) via fallback", () => {
+    expect(restoreBlockBoundaries("text<!--  BB  -->sentence")).toBe("text\nsentence");
+  });
+
+  it("round-trip: protect then restore with <!-- BB --> variant returns original", () => {
+    const original = "Some text\n- item A\n- item B";
+    const protected_ = protectBlockBoundaries(original);
+    // Simulate LLM outputting internal-whitespace variant
+    const withVariant = protected_.replace(/<!--BB-->/g, "<!-- BB -->");
+    expect(restoreBlockBoundaries(withVariant)).toBe(original);
+  });
+
+  it("round-trip: protect then restore with <!--BB__--> variant returns original", () => {
+    const original = "Intro\n## Section\n\nBody.";
+    const protected_ = protectBlockBoundaries(original);
+    const withVariant = protected_.replace(/<!--BB-->/g, "<!--BB__-->");
+    expect(restoreBlockBoundaries(withVariant)).toBe(original);
+  });
+
+  it("exact sentinel is unaffected by fallback pass (no double-processing)", () => {
+    const input = `${BB}\n- item A\n${BB}\n- item B`;
+    const restored = restoreBlockBoundaries(input);
+    expect(restored).toBe("- item A\n- item B");
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    exclude: ["tests/**/*.real-llm.test.ts", "node_modules/**"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary

- **sentinel**: `%%BB%%` → `<!--BB-->` (HTML comment、LLM 変形耐性高 — LaTeX/Liquid prior を回避)
- **restore**: 3-pass strategy (exact → fallback regex `<!-- BB -->` 等 → post-restore warn)
- **prompt**: counter-example セクション追加 (Bad examples 5 件、+135 tokens)
- **integration test**: Claude Sonnet 4.6 × 5 fixture 必須 (graceful skip 付き)
- **fix-doc-quality.ts**: 7 関数全維持 (Phase 3 削除凍結)

Closes #56

## Test plan

- [x] `npm test` — 265 tests PASS, SKIP=0
- [x] `npm run lint` — TypeScript typecheck PASS
- [ ] `npm run test:integration` — ANTHROPIC_API_KEY 設定後に CI integration-tests.yml で実行
- [x] SENTINEL_FALLBACK バリアント検出テスト 8 件追加 (unit)
- [x] integration-tests.yml — ANTHROPIC_API_KEY 未設定時は graceful skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block-boundary handling: switched sentinel to HTML-comment form and added a robust 3-pass restoration to better tolerate LLM-altered variants.

* **Tests**
  * Added real-LLM integration tests (conditional) and expanded unit tests for sentinel variant detection and round-trip preservation.

* **Chores**
  * Release bumped to 0.1.16 and CI updated to include integration test workflow.

* **Documentation**
  * CHANGELOG updated with migration guidance for existing sentinel markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->