### PR TITLE
fix(provider): ANTHROPIC_API_KEY を trim() して末尾改行を除去

### DIFF
--- a/src/provider/claude.ts
+++ b/src/provider/claude.ts
@@ -11,7 +11,7 @@ export class ClaudeProvider implements AIProvider {
   private model: string;
 
   constructor(model: string) {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
+    const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
     if (!apiKey) {
       throw new Error(
         "ANTHROPIC_API_KEY environment variable is not set. " +


### PR DESCRIPTION
## Summary

- GitHub Actions の secret 設定時に末尾の改行文字が混入すると、`node-fetch` が `*** is not a legal HTTP header value` で失敗する問題を修正
- `process.env.ANTHROPIC_API_KEY?.trim()` で末尾ホワイトスペース（改行含む）を除去

## Root cause

`node-fetch` は HTTP ヘッダー値に改行文字（`\n`）が含まれると `validateValue()` で TypeError を投げる。
GitHub Actions の `secrets.ANTHROPIC_API_KEY` が trailing newline 付きで設定されていたため、全 5 fixture が `Connection error` で FAIL した。

## Test plan

- [ ] integration-tests.yml を手動 trigger し、5 fixture 全 PASS を確認

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API key validation to properly reject whitespace-only keys for the Claude provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->