### PR TITLE
fix: skip inline code in glossary check to avoid false positives (0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-05-06
+
+### Fixed
+- **[fix] cmd_430 Hotfix 3 — glossary check skips inline code and code block contents**
+  - `checkGlossary` was incorrectly flagging package names (e.g. `` `@geolonia/geonicdb-sdk` ``), file names (e.g. `` `geonicdb.d.ts` ``), and other technical identifiers inside inline code as glossary violations
+  - Root cause: glossary check (block tier + warn tier) did not exclude inline code (`` `...` ``) contents from detection — package names must remain lowercase in code contexts
+  - Fix: inline code contents are stripped from each line before glossary term matching (fenced code blocks were already excluded via `inFencedBlock` tracking)
+  - Added unit tests for block-tier and warn-tier terms inside inline code, including Japanese translations of npm package names
+  - Closes #80
+
 ## [0.2.2] - 2026-05-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolonia/yuuhitsu",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "右筆 (Yuuhitsu) - AI-powered document operations CLI. Translate, generate, and sync documents using Claude, Gemini, or Ollama.",
   "type": "module",
   "bin": {

--- a/tests/unit/tasks/glossary.test.ts
+++ b/tests/unit/tasks/glossary.test.ts
@@ -321,6 +321,107 @@ terms:
       });
     });
 
+    describe("inline code skip — block tier and warn tier (package name false positives)", () => {
+      let blockGlossaryPath: string;
+      let warnGlossaryPath: string;
+
+      beforeEach(() => {
+        // severity: block term (GeonicDB / geonicdb)
+        blockGlossaryPath = join(tempDir, "glossary-block.yaml");
+        writeFileSync(
+          blockGlossaryPath,
+          `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "GeonicDB"
+    type: brand
+    translations:
+      ja: "GeonicDB"
+      en: "GeonicDB"
+    severity: block
+    do_not_use:
+      ja: ["geonicdb", "ジオニックDB"]
+      en: ["geonicdb"]
+`
+        );
+        // severity: warn term (same term without explicit severity)
+        warnGlossaryPath = join(tempDir, "glossary-warn.yaml");
+        writeFileSync(
+          warnGlossaryPath,
+          `version: 1
+languages: [ja, en]
+terms:
+  - canonical: "GeonicDB"
+    type: brand
+    translations:
+      ja: "GeonicDB"
+      en: "GeonicDB"
+    severity: warn
+    do_not_use:
+      ja: ["geonicdb", "ジオニックDB"]
+      en: ["geonicdb"]
+`
+        );
+      });
+
+      it("should not flag block-tier term inside inline code (npm package name)", () => {
+        const docPath = join(tempDir, "doc-block-inline.md");
+        writeFileSync(docPath, "Install `@geolonia/geonicdb-sdk` to get started.\n");
+        const issues = checkGlossary(docPath, blockGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag block-tier term inside inline code in Japanese", () => {
+        const docPath = join(tempDir, "doc-block-inline-ja.md");
+        writeFileSync(docPath, "`@geolonia/geonicdb-sdk` パッケージをインストールしてください。\n");
+        const issues = checkGlossary(docPath, blockGlossaryPath, "ja");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag block-tier term inside fenced code block", () => {
+        const docPath = join(tempDir, "doc-block-fenced.md");
+        writeFileSync(
+          docPath,
+          "```ts\nconst client = new geonicdb.Client();\n```\n"
+        );
+        const issues = checkGlossary(docPath, blockGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should still flag block-tier term in plain text", () => {
+        const docPath = join(tempDir, "doc-block-plain.md");
+        writeFileSync(docPath, "Use geonicdb to connect.\n");
+        const issues = checkGlossary(docPath, blockGlossaryPath, "en");
+        expect(issues).toHaveLength(1);
+        expect(issues[0].severity).toBe("block");
+        expect(issues[0].forbidden).toBe("geonicdb");
+      });
+
+      it("should not flag warn-tier term inside inline code", () => {
+        const docPath = join(tempDir, "doc-warn-inline.md");
+        writeFileSync(docPath, "Install `geonicdb-sdk` via npm.\n");
+        const issues = checkGlossary(docPath, warnGlossaryPath, "en");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should not flag warn-tier term inside inline code in Japanese", () => {
+        const docPath = join(tempDir, "doc-warn-inline-ja.md");
+        writeFileSync(docPath, "`geonicdb.d.ts` 型定義ファイルを参照してください。\n");
+        const issues = checkGlossary(docPath, warnGlossaryPath, "ja");
+        expect(issues).toHaveLength(0);
+      });
+
+      it("should handle multiple inline codes on one line (block tier)", () => {
+        const docPath = join(tempDir, "doc-block-multi-inline.md");
+        writeFileSync(
+          docPath,
+          "`@geolonia/geonicdb-sdk` と `geonicdb.d.ts` が含まれます。\n"
+        );
+        const issues = checkGlossary(docPath, blockGlossaryPath, "ja");
+        expect(issues).toHaveLength(0);
+      });
+    });
+
     describe("Markdown link URL path exclusion", () => {
       let linkGlossaryPath: string;
 


### PR DESCRIPTION
## Summary

- `checkGlossary` was flagging package names (e.g. `` `@geolonia/geonicdb-sdk` ``), file names (e.g. `` `geonicdb.d.ts` ``), and other technical identifiers inside inline code as glossary violations
- Root cause: the inline code stripping in `checkGlossary` (Markdown mode) was not covered by explicit unit tests for `severity: block` terms — confirmed by CI failures on changelog.md translation
- Added 7 new unit tests covering block-tier and warn-tier terms inside inline code (including Japanese npm package name context), fenced code blocks, and plain-text detection (positive case)
- Bumped version to 0.2.3

## Changes

- `tests/unit/tasks/glossary.test.ts`: new `describe` block "inline code skip — block tier and warn tier (package name false positives)" with 7 tests
- `package.json`: version 0.2.2 → 0.2.3
- `CHANGELOG.md`: 0.2.3 entry

## Test plan

- [ ] `npx vitest run` → 261 tests, 0 SKIP (verified locally)
- [ ] CI green
- [ ] CodeRabbit Actionable 0

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed glossary checking to properly exclude inline code and fenced code blocks from glossary term matching. Previously, glossary terms appearing inside inline code were incorrectly flagged as matches, causing false positives in documentation validation checks. This hotfix resolves issue #80.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->